### PR TITLE
Update remove users migration

### DIFF
--- a/db/migrate/20181108234254_remove_users_from_main_db.rb
+++ b/db/migrate/20181108234254_remove_users_from_main_db.rb
@@ -1,5 +1,6 @@
 class RemoveUsersFromMainDb < ActiveRecord::Migration[5.2]
   def change
+    return if !table_exists? :admin_users
     drop_table :admin_users
   end
 end


### PR DESCRIPTION
This PR updates `remove_users` migration to `return` in case `admin_users` table does not exists.