### PR TITLE
Feature/emission activities for the sectoral activities map

### DIFF
--- a/app/admin/indonesia_platform/emission_activities.rb
+++ b/app/admin/indonesia_platform/emission_activities.rb
@@ -1,0 +1,71 @@
+ActiveAdmin.register_page 'Indonesia Platform Emission Activities' do
+  include DataUploader::SharedAdmin
+
+  section_name = 'emission_activities'
+  platform_name = 'indonesia_platform'
+
+  controller do
+    def section_name
+      'emission_activities'
+    end
+
+    def platform_name
+      'indonesia_platform'
+    end
+
+    def s3_folder_path
+      "#{CW_FILES_PREFIX}emission_activities"
+    end
+
+    def path
+      admin_indonesia_platform_emission_activities_path
+    end
+
+    def section
+      section_repository.filter_by_section_and_platform(
+        section_name,
+        platform_name
+      )
+    end
+
+    def import_worker
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportEmissionActivities')
+    end
+
+    def section_repository
+      @section_repository ||= DataUploader::Repositories::SectionRepository.new
+    end
+
+    def dataset_repository
+      @dataset_repository ||= DataUploader::Repositories::DatasetRepository.new
+    end
+  end
+
+  menu parent: 'Indonesia Platform',
+       label: section_name.split('_').map(&:capitalize).join(' '),
+       if: proc { DataUploader::Helpers::Ability.can_view?(platform_name) }
+
+  section_proc = proc {
+    DataUploader::Repositories::SectionRepository.new.filter_by_section_and_platform(
+      section_name,
+      platform_name
+    )
+  }
+
+  datasets_proc = proc {
+    DataUploader::Repositories::DatasetRepository.new.filter_by_section(section_proc.call.id)
+  }
+
+  content do
+    render partial: 'data_uploader/admin/form_upload_datasets', locals: {
+      datasets: datasets_proc.call,
+      upload_path: admin_indonesia_platform_emission_activities_upload_datafile_path,
+      download_path: admin_indonesia_platform_emission_activities_download_datafiles_path,
+      download_single_data_file_path:
+          admin_indonesia_platform_emission_activities_download_datafile_path,
+      import_path: admin_indonesia_platform_emission_activities_run_importer_path,
+      import_button_disabled: section_proc.call.worker_logs.started.any?,
+      logs: section_proc.call.worker_logs.order(created_at: :desc)
+    }
+  end
+end

--- a/app/controllers/api/v1/emission_activities_controller.rb
+++ b/app/controllers/api/v1/emission_activities_controller.rb
@@ -1,0 +1,29 @@
+module Api
+  module V1
+    class EmissionActivitiesController < ApiController
+      def index
+        values = ::EmissionActivity::Value.includes(:location, sector: [:parent])
+        values = values.where(locations: {iso_code3: locations}) if locations
+
+        respond_to do |format|
+          format.json do
+            render json: values,
+                   each_serializer: Api::V1::EmissionActivity::ValueSerializer
+          end
+          format.csv do
+            send_data values.to_csv,
+                      type: 'text/csv',
+                      filename: 'emission_activities.csv',
+                      disposition: 'attachment'
+          end
+        end
+      end
+
+      private
+
+      def locations
+        params[:location].presence && params[:location].split(',')
+      end
+    end
+  end
+end

--- a/app/models/emission_activity.rb
+++ b/app/models/emission_activity.rb
@@ -1,0 +1,5 @@
+module EmissionActivity
+  def self.table_name_prefix
+    'emission_activity_'
+  end
+end

--- a/app/models/emission_activity/sector.rb
+++ b/app/models/emission_activity/sector.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: emission_activity_sectors
+#
+#  id         :bigint(8)        not null, primary key
+#  name       :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  parent_id  :bigint(8)
+#
+# Indexes
+#
+#  index_emission_activity_sectors_on_name_and_parent_id  (name,parent_id) UNIQUE
+#  index_emission_activity_sectors_on_parent_id           (parent_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (parent_id => emission_activity_sectors.id) ON DELETE => cascade
+#
+
+module EmissionActivity
+  class Sector < ApplicationRecord
+    belongs_to :parent,
+               class_name: 'EmissionActivity::Sector',
+               foreign_key: 'parent_id',
+               required: false
+
+    validates :name, presence: true, uniqueness: {scope: :parent}
+  end
+end

--- a/app/models/emission_activity/value.rb
+++ b/app/models/emission_activity/value.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: emission_activity_values
+#
+#  id          :bigint(8)        not null, primary key
+#  emissions   :jsonb
+#  location_id :bigint(8)
+#  sector_id   :bigint(8)
+#
+# Indexes
+#
+#  index_emission_activity_values_on_location_id  (location_id)
+#  index_emission_activity_values_on_sector_id    (sector_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (location_id => locations.id) ON DELETE => cascade
+#  fk_rails_...  (sector_id => emission_target_labels.id) ON DELETE => cascade
+#
+
+module EmissionActivity
+  class Value < ApplicationRecord
+    include ClimateWatchEngine::GenericToCsv
+
+    belongs_to :sector, class_name: 'EmissionActivity::Sector'
+    belongs_to :location
+  end
+end

--- a/app/serializers/api/v1/emission_activity/value_serializer.rb
+++ b/app/serializers/api/v1/emission_activity/value_serializer.rb
@@ -1,0 +1,24 @@
+module Api
+  module V1
+    module EmissionActivity
+      class ValueSerializer < ActiveModel::Serializer
+        attribute :location
+        attribute :sector
+        attribute :activity
+        attribute :emissions
+
+        def location
+          object.location.iso_code3
+        end
+
+        def sector
+          object.sector&.parent&.name
+        end
+
+        def activity
+          object.sector.name
+        end
+      end
+    end
+  end
+end

--- a/app/services/import_emission_activities.rb
+++ b/app/services/import_emission_activities.rb
@@ -1,0 +1,49 @@
+class ImportEmissionActivities
+  DATA_FILEPATH = "#{CW_FILES_PREFIX}emission_activities/emission_activities.csv".freeze
+
+  def call
+    cleanup
+    load_csv
+    import_data
+  end
+
+  private
+
+  def cleanup
+    EmissionActivity::Value.delete_all
+    EmissionActivity::Sector.delete_all
+  end
+
+  def load_csv
+    @csv = S3CSVReader.read(DATA_FILEPATH)
+  end
+
+  def import_data
+    @csv.each do |row|
+      location = Location.find_by(iso_code3: row[:geoid])
+
+      if location
+        EmissionActivity::Value.create!(
+          location: location,
+          sector: EmissionActivity::Sector.find_or_create_by!(sector_attributes(row)),
+          emissions: emissions(row)
+        )
+      else
+        Rails.logger.error "Location #{row[:iso]} not found"
+      end
+    end
+  end
+
+  def sector_attributes(row)
+    {
+      name: row[:subsector],
+      parent: EmissionActivity::Sector.find_or_create_by!(name: row[:sector])
+    }
+  end
+
+  def emissions(row)
+    row.headers.grep(/\d{4}/).map do |year|
+      {year: year.to_s.to_i, value: row[year]&.delete(',')&.to_f}
+    end
+  end
+end

--- a/config/data_uploader.yml
+++ b/config/data_uploader.yml
@@ -18,3 +18,7 @@ platforms:
         importer: ImportEmissionTargets
         datasets:
           - emission_targets
+      - name: emission_activities
+        importer: ImportEmissionActivities
+        datasets:
+          - emission_activities

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :emission_targets, only: [:index], defaults: { format: 'json' }
+      resources :emission_activities, only: [:index], defaults: { format: 'json' }
     end
   end
 

--- a/db/migrate/20181113093201_create_emission_activity_sectors.rb
+++ b/db/migrate/20181113093201_create_emission_activity_sectors.rb
@@ -1,0 +1,14 @@
+class CreateEmissionActivitySectors < ActiveRecord::Migration[5.2]
+  def change
+    create_table :emission_activity_sectors do |t|
+      t.text :name
+      t.references :parent,
+                   foreign_key: {
+                     to_table: :emission_activity_sectors,
+                     on_delete: :cascade
+                   }
+      t.timestamps
+    end
+    add_index :emission_activity_sectors, [:name, :parent_id], unique: true
+  end
+end

--- a/db/migrate/20181113093205_create_emission_activity_values.rb
+++ b/db/migrate/20181113093205_create_emission_activity_values.rb
@@ -1,0 +1,16 @@
+class CreateEmissionActivityValues < ActiveRecord::Migration[5.2]
+  def change
+    create_table :emission_activity_values do |t|
+      t.references :location,
+                   foreign_key: {
+                     on_delete: :cascade
+                   }
+      t.references :sector,
+                   foreign_key: {
+                     to_table: :emission_activity_sectors,
+                     on_delete: :cascade
+                   }
+      t.jsonb :emissions
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_09_115558) do
+ActiveRecord::Schema.define(version: 2018_11_13_093205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,23 @@ ActiveRecord::Schema.define(version: 2018_11_09_115558) do
     t.bigint "section_id"
     t.index ["section_id", "name"], name: "datasets_section_id_name_key", unique: true
     t.index ["section_id"], name: "index_datasets_on_section_id"
+  end
+
+  create_table "emission_activity_sectors", force: :cascade do |t|
+    t.text "name"
+    t.bigint "parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "parent_id"], name: "index_emission_activity_sectors_on_name_and_parent_id", unique: true
+    t.index ["parent_id"], name: "index_emission_activity_sectors_on_parent_id"
+  end
+
+  create_table "emission_activity_values", force: :cascade do |t|
+    t.bigint "location_id"
+    t.bigint "sector_id"
+    t.jsonb "emissions"
+    t.index ["location_id"], name: "index_emission_activity_values_on_location_id"
+    t.index ["sector_id"], name: "index_emission_activity_values_on_sector_id"
   end
 
   create_table "emission_target_labels", force: :cascade do |t|
@@ -164,6 +181,9 @@ ActiveRecord::Schema.define(version: 2018_11_09_115558) do
   end
 
   add_foreign_key "datasets", "sections"
+  add_foreign_key "emission_activity_sectors", "emission_activity_sectors", column: "parent_id", on_delete: :cascade
+  add_foreign_key "emission_activity_values", "emission_activity_sectors", column: "sector_id", on_delete: :cascade
+  add_foreign_key "emission_activity_values", "locations", on_delete: :cascade
   add_foreign_key "emission_target_values", "emission_target_labels", column: "label_id", on_delete: :cascade
   add_foreign_key "emission_target_values", "emission_target_sectors", column: "sector_id", on_delete: :cascade
   add_foreign_key "emission_target_values", "locations", on_delete: :cascade

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -5,6 +5,7 @@ namespace :db do
     Rake::Task['location_members:import'].invoke
     Rake::Task['historical_emissions:import'].invoke
     Rake::Task['emission_targets:import'].invoke
+    Rake::Task['emission_activities:import'].invoke
     puts 'All done!'
   end
 end

--- a/lib/tasks/import_emission_activities.rake
+++ b/lib/tasks/import_emission_activities.rake
@@ -1,0 +1,8 @@
+namespace :emission_activities do
+  desc 'Imports emission activities'
+  task import: :environment do
+    TimedLogger.log('import emission activities') do
+      ImportEmissionActivities.new.call
+    end
+  end
+end

--- a/spec/controllers/api/v1/emission_activities_controller_spec.rb
+++ b/spec/controllers/api/v1/emission_activities_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe Api::V1::EmissionActivitiesController, type: :controller do
+  context do
+    let!(:bali_activities) {
+      location = FactoryBot.create(:location, iso_code3: 'ID.BA')
+      FactoryBot.create_list(:emission_activity_value, 2, location: location)
+    }
+    let!(:papua_activities) {
+      location = FactoryBot.create(:location, iso_code3: 'ID.PA')
+      FactoryBot.create_list(:emission_activity_value, 3, location: location)
+    }
+
+    describe 'GET index' do
+      it 'returns a successful 200 response' do
+        get :index, format: :json
+        expect(response).to be_successful
+      end
+
+      it 'lists all emission activities' do
+        get :index, format: :json
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.length).to eq(5)
+      end
+
+      it 'filters emission activities by location' do
+        get :index, params: {location: 'ID.BA'}, format: :json
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.length).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: admin_users
+#
+#  id                     :bigint(8)        not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  role                   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_admin_users_on_email                 (email) UNIQUE
+#  index_admin_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
+
 FactoryBot.define do
   factory :admin_user do
     sequence(:email) { |n| "user#{n}@example.com" }

--- a/spec/factories/emission_activity_sector.rb
+++ b/spec/factories/emission_activity_sector.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :emission_activity_sector, class: 'EmissionActivity::Sector' do
+    sequence(:name) { |n| "Sector#{n}" }
+  end
+end

--- a/spec/factories/emission_activity_value.rb
+++ b/spec/factories/emission_activity_value.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :emission_activity_value, class: 'EmissionActivity::Value' do
+    location
+    association :sector, factory: :emission_activity_sector
+    emissions { [{year: 2010, value: 3000}, {year: 2011, value: 3030}] }
+  end
+end

--- a/spec/factories/emission_target_labels.rb
+++ b/spec/factories/emission_target_labels.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: emission_target_labels
+#
+#  id         :bigint(8)        not null, primary key
+#  name       :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_emission_target_labels_on_name  (name) UNIQUE
+#
+
 FactoryBot.define do
   factory :emission_target_label, class: 'EmissionTarget::Label' do
     sequence(:name) { |n| "Label#{n}" }

--- a/spec/factories/emission_target_sectors.rb
+++ b/spec/factories/emission_target_sectors.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: emission_target_sectors
+#
+#  id         :bigint(8)        not null, primary key
+#  name       :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_emission_target_sectors_on_name  (name) UNIQUE
+#
+
 FactoryBot.define do
   factory :emission_target_sector, class: 'EmissionTarget::Sector' do
     sequence(:name) { |n| "Sector#{n}" }

--- a/spec/factories/emission_target_values.rb
+++ b/spec/factories/emission_target_values.rb
@@ -1,3 +1,30 @@
+# == Schema Information
+#
+# Table name: emission_target_values
+#
+#  id           :bigint(8)        not null, primary key
+#  first_value  :float
+#  second_value :float
+#  year         :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  label_id     :bigint(8)
+#  location_id  :bigint(8)
+#  sector_id    :bigint(8)
+#
+# Indexes
+#
+#  index_emission_target_values_on_label_id     (label_id)
+#  index_emission_target_values_on_location_id  (location_id)
+#  index_emission_target_values_on_sector_id    (sector_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (label_id => emission_target_labels.id) ON DELETE => cascade
+#  fk_rails_...  (location_id => locations.id) ON DELETE => cascade
+#  fk_rails_...  (sector_id => emission_target_sectors.id) ON DELETE => cascade
+#
+
 FactoryBot.define do
   factory :emission_target_value, class: 'EmissionTarget::Value' do
     location

--- a/spec/models/emission_activity/sector_spec.rb
+++ b/spec/models/emission_activity/sector_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe EmissionActivity::Sector, type: :model do
+  it 'should be invalid when name not present' do
+    expect(
+      FactoryBot.build(:emission_activity_sector, name: nil)
+    ).to have(1).errors_on(:name)
+  end
+
+  it 'should be invalid when name in the parent scope is not unique' do
+    parent = FactoryBot.create(:emission_activity_sector, name: 'Waste')
+    FactoryBot.create(:emission_activity_sector, name: 'Landfills', parent: parent)
+    expect(
+      FactoryBot.build(:emission_activity_sector, name: 'Landfills', parent: parent)
+    ).to have(1).errors_on(:name)
+  end
+
+  it 'should be valid when name in the parent scope is unique' do
+    FactoryBot.create(
+      :emission_activity_sector,
+      name: 'Transport',
+      parent: FactoryBot.create(:emission_activity_sector)
+    )
+    expect(
+      FactoryBot.build(
+        :emission_activity_sector,
+        name: 'Transport',
+        parent: FactoryBot.create(:emission_activity_sector)
+      )
+    ).to be_valid
+  end
+
+  it 'should be valid' do
+    expect(FactoryBot.build(:emission_activity_sector)).to be_valid
+  end
+end

--- a/spec/models/emission_activity/value_spec.rb
+++ b/spec/models/emission_activity/value_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe EmissionActivity::Value, type: :model do
+  it 'should be invalid when sector not present' do
+    expect(
+      FactoryBot.build(:emission_activity_value, sector: nil)
+    ).to have(1).errors_on(:sector)
+  end
+
+  it 'should be valid' do
+    expect(FactoryBot.build(:emission_activity_value)).to be_valid
+  end
+end

--- a/spec/services/import_emission_activities_spec.rb
+++ b/spec/services/import_emission_activities_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+object_contents = {
+  "#{CW_FILES_PREFIX}emission_activities/emission_activities.csv" => <<~END_OF_CSV,
+    geoid,Source,Sector,Subsector,2010,2011,2012,2013,2014
+    ID.AC,SIGNS,Forestry,non-cropland to cropland,3994.7,2386.15,2123.75,1071.36,
+    ID.AC,SIGNS,Forestry,Peat fire,,,,,
+    ID.AC,SIGNS,Waste,Landfills,"20,752.49","21,837.04","22,713.70","22,958.87","22,977.31"
+    ID.BA,SIGNS,Agriculture,Enteric Fermentation,614.6,574.18,584.08,435.95,499.1
+  END_OF_CSV
+}
+
+RSpec.describe ImportEmissionActivities do
+  subject { ImportEmissionActivities.new.call }
+
+  before :all do
+    Aws.config[:s3] = {
+      stub_responses: {
+        get_object: lambda do |context|
+          {body: object_contents[context.params[:key]]}
+        end
+      }
+    }
+  end
+
+  before :each do
+    FactoryBot.create(:location, iso_code3: 'ID.AC')
+    FactoryBot.create(:location, iso_code3: 'ID.BA')
+  end
+
+  after :all do
+    Aws.config[:s3] = {
+      stub_responses: nil
+    }
+  end
+
+  it 'Creates new sector records' do
+    expect { subject }.to change { EmissionActivity::Sector.count }.by(7)
+  end
+
+  it 'Creates new emission activity values' do
+    expect { subject }.to change { EmissionActivity::Value.count }.by(4)
+  end
+end

--- a/spec/services/import_emission_targets_spec.rb
+++ b/spec/services/import_emission_targets_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ImportEmissionTargets do
     expect { subject }.to change { EmissionTarget::Sector.count }.by(3)
   end
 
-  it 'Creates new quantification records' do
+  it 'Creates new emission target values' do
     expect { subject }.to change { EmissionTarget::Value.count }.by(4)
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/161651189

`bundle exec rake db:migrate`
`bundle exec rake db:admin_boilerplate:create`

`bundle exec rake emission_activities:import`

API endpoint `/api/v1/emission_activities` returns data in a generic way:
```
{
  location: "Aceh",
  location_iso_code3: "ID.AC",
  sector: "Agriculture",
  activity: "Enteric Fermentation",
  emissions: [
    {
      year: 2010,
      value: 1043.92
    },
    {
      year: 2011,
      value: 609.9
    },
    {
      year: 2012,
      value: 684.36
    },
    {
      year: 2013,
      value: 555.31
    },
    {
      year: 2014,
      value: 685.7
    }
  ]
}

```