### PR TITLE
Add content management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ git 'https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git' do
   gem 'climate_watch_engine', '~> 1.3.2'
   gem 'cw_locations', '~> 1.3.1', require: 'locations'
   gem 'cw_historical_emissions', '~> 1.3.1', require: 'historical_emissions'
-  gem 'cw_data_uploader', '~> 0.3.2', require: 'data_uploader'
+  gem 'cw_data_uploader', '~> 0.3.3', require: 'data_uploader'
 end
 
 # for debugging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git
-  revision: 29f07c0dad9d793867c49833ce2e0ca44111eb1f
+  revision: 17a0c1365f321e095fed2d07b1bf99a44991932e
   specs:
     climate_watch_engine (1.3.2)
       aws-sdk-s3 (~> 1)
       rails (~> 5.2.0)
-    cw_data_uploader (0.3.2)
+    cw_data_uploader (0.3.3)
       activeadmin
       aws-sdk-rails (~> 2)
       aws-sdk-s3 (~> 1)
@@ -99,8 +99,8 @@ GEM
     arel (9.0.0)
     ast (2.4.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.109.0)
-    aws-sdk-core (3.36.0)
+    aws-partitions (1.112.0)
+    aws-sdk-core (3.38.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -375,7 +375,7 @@ DEPENDENCIES
   byebug
   capybara (~> 2.13)
   climate_watch_engine (~> 1.3.2)!
-  cw_data_uploader (~> 0.3.2)!
+  cw_data_uploader (~> 0.3.3)!
   cw_historical_emissions (~> 1.3.1)!
   cw_locations (~> 1.3.1)!
   devise

--- a/app/admin/content_management.rb
+++ b/app/admin/content_management.rb
@@ -1,0 +1,34 @@
+ActiveAdmin.register SectionContent do
+  actions :all, except: [:destroy, :create, :new]
+  filter :locale
+  config.sort_order = 'order_asc'
+  permit_params :title, :description
+
+  form do |f|
+    f.inputs 'Main Section' do
+      f.input :name, input_html: {readonly: true}
+      f.input :title, label: 'Title'
+      f.input :description, label: 'Description'
+    end
+    f.actions
+  end
+
+  index download_links: false, new_link: false, new_record: false, allow_destroy: false do
+    column :name
+    column :locale
+    column :title
+    column :description
+    column :created_at
+    column :updated_at
+    actions
+  end
+
+  show do
+    h3 section_content.name
+    table_for section_content do
+      column :name
+      column :title
+      column :description
+    end
+  end
+end

--- a/app/admin/indonesia_platform/emission_activities.rb
+++ b/app/admin/indonesia_platform/emission_activities.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register_page 'Indonesia Platform Emission Activities' do
     end
 
     def import_worker
-      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportEmissionActivities')
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportEmissionActivities', current_admin_user.email)
     end
 
     def section_repository

--- a/app/admin/indonesia_platform/emission_targets.rb
+++ b/app/admin/indonesia_platform/emission_targets.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register_page 'Indonesia Platform Emission Targets' do
     end
 
     def import_worker
-      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportEmissionTargets')
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportEmissionTargets', current_admin_user.email)
     end
 
     def section_repository

--- a/app/admin/indonesia_platform/historical_emissions.rb
+++ b/app/admin/indonesia_platform/historical_emissions.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register_page 'Indonesia Platform Historical Emissions' do
     end
 
     def import_worker
-      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportHistoricalEmissions')
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportHistoricalEmissions', current_admin_user.email)
     end
 
     def section_repository

--- a/app/admin/indonesia_platform/locations.rb
+++ b/app/admin/indonesia_platform/locations.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register_page 'Indonesia Platform Locations' do
     end
 
     def import_worker
-      DataUploader::BaseImportWorker.perform_async(section.id, 'Locations::ImportLocations')
+      DataUploader::BaseImportWorker.perform_async(section.id, 'Locations::ImportLocations', current_admin_user.email)
     end
 
     def section_repository

--- a/app/admin/indonesia_platform/locations_members.rb
+++ b/app/admin/indonesia_platform/locations_members.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register_page 'Indonesia Platform Locations Members' do
     end
 
     def import_worker
-      DataUploader::BaseImportWorker.perform_async(section.id, 'Locations::ImportLocationMembers')
+      DataUploader::BaseImportWorker.perform_async(section.id, 'Locations::ImportLocationMembers', current_admin_user.email)
     end
 
     def section_repository

--- a/app/controllers/api/v1/section_content_controller.rb
+++ b/app/controllers/api/v1/section_content_controller.rb
@@ -1,9 +1,16 @@
 module Api
   module V1
     class SectionContentController < ApiController
+      DEFAULT_LANGUAGE = 'en'.freeze
+
       def index
         locale = params[:locale]
-        section_contents = locale ? SectionContent.where(locale: locale) : SectionContent.all
+        section_contents =
+          if locale
+            SectionContent.where(locale: locale)
+          else
+            SectionContent.where(locale: DEFAULT_LANGUAGE)
+          end
 
         respond_to do |format|
           format.json do

--- a/app/controllers/api/v1/section_content_controller.rb
+++ b/app/controllers/api/v1/section_content_controller.rb
@@ -4,13 +4,9 @@ module Api
       DEFAULT_LANGUAGE = 'en'.freeze
 
       def index
-        locale = params[:locale]
-        section_contents =
-          if locale
-            SectionContent.where(locale: locale)
-          else
-            SectionContent.where(locale: DEFAULT_LANGUAGE)
-          end
+        section_contents = SectionContent.where(
+          locale: params[:locale].presence || DEFAULT_LANGUAGE
+        )
 
         respond_to do |format|
           format.json do

--- a/app/controllers/api/v1/section_content_controller.rb
+++ b/app/controllers/api/v1/section_content_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1
+    class SectionContentController < ApiController
+      def index
+        locale = params[:locale]
+        section_contents = locale ? SectionContent.where(locale: locale) : SectionContent.all
+
+        respond_to do |format|
+          format.json do
+            render json: section_contents,
+                   each_serializer: Api::V1::SectionContentSerializer
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/section_content.rb
+++ b/app/models/section_content.rb
@@ -1,0 +1,2 @@
+class SectionContent < ApplicationRecord
+end

--- a/app/serializers/api/v1/section_content_serializer.rb
+++ b/app/serializers/api/v1/section_content_serializer.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class SectionContentSerializer < ActiveModel::Serializer
+      attributes :slug, :title, :description, :locale
+    end
+  end
+end

--- a/config/content_management_sections.yml
+++ b/config/content_management_sections.yml
@@ -1,0 +1,47 @@
+locales: [en, id]
+sections:
+  - name: HOMEPAGE
+    slug: intro
+    order: 1
+  - name: HOMEPAGE_province
+    slug: province
+    order: 2
+  - name: HOMEPAGE_climate-watch
+    slug: climate-watch-disclaimer
+    order: 3
+  - name: HOMEPAGE_climate-watch-button
+    slug: climate-watch-button
+    order: 4
+  - name: HOMEPAGE_highlighted-stories
+    slug: highlighted-stories
+    order: 5
+  - name: HOMEPAGE_highlighted-stories-button
+    slug: highlighted-stories-button
+    order: 6
+  - name: NATIONAL_CONTEXT
+    slug: national-context
+    order: 7
+  - name: NATIONAL_CONTEXT_socioeconomic-indicators
+    slug: socioeconomic-indicators
+    order: 8
+  - name: NATIONAL_CONTEXT_historical-emissions
+    slug: historical-emissions
+    order: 9
+  - name: NATIONAL_CONTEXT_climate-funding
+    slug: climate-funding
+    order: 10
+  - name: CLIMATE_GOALS
+    slug: climate-goals
+    order: 11
+  - name: CLIMATE_GOALS_overview
+    slug: climate-goals-overview
+    order: 12
+  - name: CLIMATE_GOALS_mitigation
+    slug: climate-goals-mitigation
+    order: 13
+  - name: CLIMATE_GOALS_adaptation
+    slug: climate-goals-adaptation
+    order: 14
+  - name: CLIMATE_GOALS_sectoral-information
+    slug: climate-goals-sectoral-information
+    order: 15

--- a/config/initial_sections_content.yml
+++ b/config/initial_sections_content.yml
@@ -1,0 +1,62 @@
+sections:
+  - slug: intro
+    locale: en
+    title:
+    description: Indonesia Climate Explorer offers open data, visualizations and analysis to help policymakers, researchers and other stakeholders gather insights on Inonesia’s climate progress.
+  - slug: province
+    locale: en
+    title: Province module data
+    description: "34 provinces in Indonesia reflects diverse condition geographically and socioeconomically which lead to different challenges to tackle climate change. Explore individual provinces circumstance and compare this information across provinces to address your question on:<br><br><li>Which sectors dominate the provincial GHG emissions?</li><li>How much progress to mitigating climate change has been made so far?</li><li>Which province is the most vulnerable and adaptive on climate change?</li><li>What type of activities are the primary source of province emissions?</li><li>What are provinces doing to reduce their emissions?</li>"
+  - slug: climate-watch-disclaimer
+    locale: en
+    title: 
+    description: Improving understanding of the possible policy and development paths that could lead to decarbonization of the economy in different countries by providing high-quality, global data.
+  - slug: climate-watch-button
+    locale: en
+    title: Explore The Global Site
+    description:
+  - slug: highlighted-stories
+    locale: en
+    title: Highlighted Stories
+    description:
+  - slug: highlighted-stories-button
+    locale: en
+    title: More Stories
+    description:
+  - slug: national-context
+    locale: en
+    title: National Context
+    description: "This section provides context for Indonesias’s climate change response, including information on provincial development priorities, population, economy, energy, and climate risks from natural disasters."
+  - slug: socioeconomic-indicators
+    locale: en
+    title: Socioeconomic Indicators
+    description:
+  - slug: historical-emissions
+    locale: en
+    title: Historical Emissions
+    description:
+  - slug: climate-funding
+    locale: en
+    title: Climate Funding
+    description:
+  - slug: climate-goals
+    locale: en
+    title: Climate Goals
+    description: This section provides context for Indonesias’s climate change response, including information on provincial development priorities, population, economy, energy, and climate risks from natural disasters.
+  - slug: climate-goals-overview
+    locale: en
+    title: Overview
+    description:
+  - slug: climate-goals-mitigation
+    locale: en
+    title: Mitigation
+    description:
+  - slug: climate-goals-adaptation
+    locale: en
+    title: Adaptation
+    description:
+  - slug: climate-goals-sectoral-information
+    locale: en
+    title: Sectoral Information
+    description:
+        

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :emission_targets, only: [:index], defaults: { format: 'json' }
       resources :emission_activities, only: [:index], defaults: { format: 'json' }
+      resources :section_content, only: [:index], defaults: { format: 'json' }
     end
   end
 

--- a/db/migrate/20181114144859_add_user_email_to_worker_logs.data_uploader.rb
+++ b/db/migrate/20181114144859_add_user_email_to_worker_logs.data_uploader.rb
@@ -1,0 +1,6 @@
+# This migration comes from data_uploader (originally 20181113183506)
+class AddUserEmailToWorkerLogs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :worker_logs, :user_email, :string
+  end
+end

--- a/db/migrate/20181114150615_create_section_content.rb
+++ b/db/migrate/20181114150615_create_section_content.rb
@@ -1,0 +1,14 @@
+class CreateSectionContent < ActiveRecord::Migration[5.2]
+  def change
+    create_table :section_contents do |t|
+      t.string :title
+      t.text :description
+      t.string :locale
+      t.string :slug
+      t.string :name
+      t.integer :order
+      t.datetime :updated_at
+      t.datetime :created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_13_093205) do
+ActiveRecord::Schema.define(version: 2018_11_14_150615) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,16 @@ ActiveRecord::Schema.define(version: 2018_11_13_093205) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.bigint "report_id", null: false
+    t.text "section_slug", null: false
+    t.text "slug", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["report_id", "section_slug", "slug"], name: "categories_report_id_section_slug_slug_key", unique: true
+    t.index ["report_id"], name: "index_categories_on_report_id"
   end
 
   create_table "datasets", force: :cascade do |t|
@@ -135,6 +145,16 @@ ActiveRecord::Schema.define(version: 2018_11_13_093205) do
     t.index ["parent_id"], name: "index_historical_emissions_sectors_on_parent_id"
   end
 
+  create_table "indicators", force: :cascade do |t|
+    t.bigint "target_id", null: false
+    t.text "slug", null: false
+    t.json "values"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["target_id", "slug"], name: "indicators_target_id_slug_key", unique: true
+    t.index ["target_id"], name: "index_indicators_on_target_id"
+  end
+
   create_table "location_members", force: :cascade do |t|
     t.bigint "location_id"
     t.bigint "member_id"
@@ -162,11 +182,57 @@ ActiveRecord::Schema.define(version: 2018_11_13_093205) do
     t.index ["name"], name: "platforms_name_key", unique: true
   end
 
+  create_table "reports", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_reports_on_user_id"
+  end
+
+  create_table "section_contents", force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.string "locale"
+    t.string "slug"
+    t.string "name"
+    t.integer "order"
+    t.datetime "updated_at"
+    t.datetime "created_at"
+  end
+
   create_table "sections", force: :cascade do |t|
     t.string "name"
     t.bigint "platform_id"
     t.index ["platform_id", "name"], name: "sections_platform_id_name_key", unique: true
     t.index ["platform_id"], name: "index_sections_on_platform_id"
+  end
+
+  create_table "targets", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.text "slug", null: false
+    t.integer "year", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id", "slug", "year"], name: "targets_category_id_slug_year_key", unique: true
+    t.index ["category_id"], name: "index_targets_on_category_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.boolean "is_admin", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.string "country_iso_code", limit: 3, default: "XXX", null: false
+    t.string "authentication_token", limit: 30
+    t.text "first_name", null: false
+    t.text "last_name", null: false
+    t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   create_table "worker_logs", force: :cascade do |t|
@@ -176,10 +242,12 @@ ActiveRecord::Schema.define(version: 2018_11_13_093205) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "error"
+    t.string "user_email"
     t.index ["jid"], name: "index_worker_logs_on_jid"
     t.index ["section_id"], name: "index_worker_logs_on_section_id"
   end
 
+  add_foreign_key "categories", "reports", on_delete: :cascade
   add_foreign_key "datasets", "sections"
   add_foreign_key "emission_activity_sectors", "emission_activity_sectors", column: "parent_id", on_delete: :cascade
   add_foreign_key "emission_activity_values", "emission_activity_sectors", column: "sector_id", on_delete: :cascade
@@ -194,8 +262,10 @@ ActiveRecord::Schema.define(version: 2018_11_13_093205) do
   add_foreign_key "historical_emissions_records", "locations", on_delete: :cascade
   add_foreign_key "historical_emissions_sectors", "historical_emissions_data_sources", column: "data_source_id", on_delete: :cascade
   add_foreign_key "historical_emissions_sectors", "historical_emissions_sectors", column: "parent_id", on_delete: :cascade
+  add_foreign_key "indicators", "targets", on_delete: :cascade
   add_foreign_key "location_members", "locations", column: "member_id", on_delete: :cascade
   add_foreign_key "location_members", "locations", on_delete: :cascade
   add_foreign_key "sections", "platforms"
+  add_foreign_key "targets", "categories", on_delete: :cascade
   add_foreign_key "worker_logs", "sections"
 end

--- a/lib/tasks/add_content_management_records.rake
+++ b/lib/tasks/add_content_management_records.rake
@@ -1,0 +1,19 @@
+namespace :db do
+  desc 'Add content management records'
+  task add_content_management_records: :environment do
+    file = File.join(Rails.root, 'config/content_management_sections.yml')
+    config = YAML.load_file(file)
+
+    config['locales'].each do |locale|
+      config['sections'].each do |section|
+        SectionContent.find_or_create_by(slug: section['slug'], locale: locale) do |s|
+          s.name = section['name']
+          s.order = section['order']
+          s.locale = locale
+        end
+      end
+    end
+
+    puts 'All sections for content management created!'
+  end
+end

--- a/lib/tasks/add_initial_sections_content.rake
+++ b/lib/tasks/add_initial_sections_content.rake
@@ -1,0 +1,15 @@
+namespace :db do
+  desc 'Add initial sections content'
+  task add_initial_sections_content: :environment do
+    file = File.join(Rails.root, 'config/initial_sections_content.yml')
+    config = YAML.load_file(file)
+
+    config['sections'].each do |section|
+      s = SectionContent.find_by(slug: section['slug'], locale: section['locale'])
+      s.update(title: section['title'])
+      s.update(description: section['description'])
+    end
+
+    puts 'Sections seeded!'
+  end
+end


### PR DESCRIPTION
This PR adds content management for Indonesia platform, including translations. Possible locales are `en` and `id`. 
Added query param `locale` to get records for specified language. If no locale is provided, API is returning english translations.

On the admin panel it looks as follows:
![image](https://user-images.githubusercontent.com/6136899/48497864-e00db580-e82c-11e8-82b8-bcfed05a748f.png)
Each slug is duplicated for the translation purposes. The order imitates the way it looks on frontend. It's designed to fetch the API by slug and locale, the name columns are just for better mind mapping.
Each section has `title` and `description` but both are optional (in some cases it makes sense to only update the description, for example for the intro text on Homepage and for some only the title like the titles for buttons).

I added rake task with initial content (for now, only for the sections that are visible currently so it will need updating in the process).

Take a look at the `content_management_sections.yml` file as this is the place where we define what sections need to appear on admin panel and what are the `slug`s for FE.

I didn't add any relationship to simulate section-subsections as for some of the content it didn't make sense (like for buttons) but I think the names themselves are descriptive enough to know what goes where.

To test run 🏃‍♀️ :
- `rake db:add_content_management_records`
- `rake db:add_initial_sections_content` 
