### PR TITLE
historical emissions: add metrics to records and metadata endpoints

### DIFF
--- a/app/decorators/controllers/historical_emissions/historical_emissions_controller_decorator.rb
+++ b/app/decorators/controllers/historical_emissions/historical_emissions_controller_decorator.rb
@@ -1,0 +1,30 @@
+HistoricalEmissions::HistoricalEmissionsController.class_eval do
+  HistoricalEmissionsMetadata = Struct.new(
+    :data_sources,
+    :sectors,
+    :metrics,
+    :gases,
+    :gwps,
+    :locations
+  ) do
+    alias_method :read_attribute_for_serialization, :send
+
+    def self.model_name
+      'metadata'
+    end
+  end
+
+  def meta
+    render(
+      json: HistoricalEmissionsMetadata.new(
+        merged_records(grouped_records),
+        ::HistoricalEmissions::Sector.all,
+        ::HistoricalEmissions::Metric.all,
+        ::HistoricalEmissions::Gas.all,
+        ::HistoricalEmissions::Gwp.all,
+        Location.all
+      ),
+      serializer: ::HistoricalEmissions::MetadataSerializer
+    )
+  end
+end

--- a/app/decorators/models/historical_emissions/record_decorator.rb
+++ b/app/decorators/models/historical_emissions/record_decorator.rb
@@ -1,0 +1,3 @@
+HistoricalEmissions::Record.class_eval do
+  belongs_to :metric, class_name: 'HistoricalEmissions::Metric'
+end

--- a/app/decorators/serializers/historical_emissions/metadata_serializer_decorator.rb
+++ b/app/decorators/serializers/historical_emissions/metadata_serializer_decorator.rb
@@ -1,0 +1,9 @@
+HistoricalEmissions::MetadataSerializer.class_eval do
+  attribute :metric
+
+  def metric
+    object.metrics.map do |m|
+      m.slice(:id, :name, :unit)
+    end
+  end
+end

--- a/app/decorators/serializers/historical_emissions/record_serializer_decorator.rb
+++ b/app/decorators/serializers/historical_emissions/record_serializer_decorator.rb
@@ -1,0 +1,7 @@
+HistoricalEmissions::RecordSerializer.class_eval do
+  belongs_to :metric
+
+  def metric
+    object.metric.name
+  end
+end

--- a/app/decorators/services/historical_emissions/import_historical_emissions_decorator.rb
+++ b/app/decorators/services/historical_emissions/import_historical_emissions_decorator.rb
@@ -8,12 +8,12 @@ HistoricalEmissions::ImportHistoricalEmissions.class_eval do
   def record_attributes(row)
     puts row
     {
-      location: Location.find_by(iso_code3: row[:geoid]&.strip),
+      location: Location.find_by(iso_code3: row[:geoid]),
       data_source: HistoricalEmissions::DataSource.find_by(name: row[:source]),
       sector: HistoricalEmissions::Sector.find_by(name: row[:sector]),
       gas: HistoricalEmissions::Gas.find_or_create_by(name: row[:gas]),
       gwp: HistoricalEmissions::Gwp.find_or_create_by(name: 'AR2'),
-      metric: row[:metric],
+      metric: HistoricalEmissions::Metric.find_or_create_by(name: row[:metric], unit: row[:unit]),
       emissions: emissions(row)
     }
   end

--- a/app/models/historical_emissions/metric.rb
+++ b/app/models/historical_emissions/metric.rb
@@ -1,0 +1,7 @@
+module HistoricalEmissions
+  class Metric < ApplicationRecord
+    validates_presence_of :name, :unit
+
+    validates :unit, uniqueness: {scope: :name}
+  end
+end

--- a/app/models/province/climate_plan.rb
+++ b/app/models/province/climate_plan.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: province_climate_plans
+#
+#  id                    :bigint(8)        not null, primary key
+#  mitigation_activities :text
+#  sector                :string
+#  source                :string
+#  sub_sector            :string
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  location_id           :bigint(8)
+#
+# Indexes
+#
+#  index_province_climate_plans_on_location_id  (location_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (location_id => locations.id) ON DELETE => cascade
+#
+
 module Province
   class ClimatePlan < ApplicationRecord
     belongs_to :location

--- a/app/models/province/development_plan.rb
+++ b/app/models/province/development_plan.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: province_development_plans
+#
+#  id                           :bigint(8)        not null, primary key
+#  rpjmd_period                 :string
+#  source                       :string
+#  supportive_mission_statement :text
+#  supportive_policy_directions :jsonb
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  location_id                  :bigint(8)
+#
+# Indexes
+#
+#  index_province_development_plans_on_location_id  (location_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (location_id => locations.id) ON DELETE => cascade
+#
+
 module Province
   class DevelopmentPlan < ApplicationRecord
     include ClimateWatchEngine::GenericToCsv

--- a/db/migrate/20181122173454_create_historical_emissions_metrics.rb
+++ b/db/migrate/20181122173454_create_historical_emissions_metrics.rb
@@ -1,0 +1,19 @@
+class CreateHistoricalEmissionsMetrics < ActiveRecord::Migration[5.2]
+  def change
+    create_table :historical_emissions_metrics do |t|
+      t.string :name, null: false
+      t.string :unit, null: false
+    end
+
+    add_index :historical_emissions_metrics, [:name, :unit], unique: true
+
+    remove_column :historical_emissions_records, :metric, :text
+
+    add_reference :historical_emissions_records,
+                  :metric,
+                  foreign_key: {
+                    to_table: :historical_emissions_metrics,
+                    on_delete: :cascade
+                  }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_21_115651) do
+ActiveRecord::Schema.define(version: 2018_11_22_173454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,6 +141,12 @@ ActiveRecord::Schema.define(version: 2018_11_21_115651) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "historical_emissions_metrics", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "unit", null: false
+    t.index ["name", "unit"], name: "index_historical_emissions_metrics_on_name_and_unit", unique: true
+  end
+
   create_table "historical_emissions_records", force: :cascade do |t|
     t.bigint "location_id"
     t.bigint "data_source_id"
@@ -150,11 +156,12 @@ ActiveRecord::Schema.define(version: 2018_11_21_115651) do
     t.jsonb "emissions"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "metric"
+    t.bigint "metric_id"
     t.index ["data_source_id"], name: "index_historical_emissions_records_on_data_source_id"
     t.index ["gas_id"], name: "index_historical_emissions_records_on_gas_id"
     t.index ["gwp_id"], name: "index_historical_emissions_records_on_gwp_id"
     t.index ["location_id"], name: "index_historical_emissions_records_on_location_id"
+    t.index ["metric_id"], name: "index_historical_emissions_records_on_metric_id"
     t.index ["sector_id"], name: "index_historical_emissions_records_on_sector_id"
   end
 
@@ -281,6 +288,7 @@ ActiveRecord::Schema.define(version: 2018_11_21_115651) do
   add_foreign_key "historical_emissions_records", "historical_emissions_data_sources", column: "data_source_id", on_delete: :cascade
   add_foreign_key "historical_emissions_records", "historical_emissions_gases", column: "gas_id", on_delete: :cascade
   add_foreign_key "historical_emissions_records", "historical_emissions_gwps", column: "gwp_id", on_delete: :cascade
+  add_foreign_key "historical_emissions_records", "historical_emissions_metrics", column: "metric_id", on_delete: :cascade
   add_foreign_key "historical_emissions_records", "historical_emissions_sectors", column: "sector_id", on_delete: :cascade
   add_foreign_key "historical_emissions_records", "locations", on_delete: :cascade
   add_foreign_key "historical_emissions_sectors", "historical_emissions_data_sources", column: "data_source_id", on_delete: :cascade

--- a/spec/factories/historical_emissions_metric.rb
+++ b/spec/factories/historical_emissions_metric.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :historical_emissions_metric, class: 'HistoricalEmissions::Metric' do
+    sequence(:name) { |n| "Name#{n}" }
+    sequence(:unit) { |n| "Unit#{n}" }
+  end
+end

--- a/spec/models/historical_emissions/metric_spec.rb
+++ b/spec/models/historical_emissions/metric_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe HistoricalEmissions::Metric, type: :model do
+  it 'should be invalid when name not present' do
+    expect(
+      FactoryBot.build(:historical_emissions_metric, name: nil)
+    ).to have(1).errors_on(:name)
+  end
+
+  it 'should be invalid when unit not present' do
+    expect(
+      FactoryBot.build(:historical_emissions_metric, unit: nil)
+    ).to have(1).errors_on(:unit)
+  end
+
+  it 'should be invalid when name with unit is taken' do
+    FactoryBot.create(:historical_emissions_metric, name: 'metric', unit: 'unit')
+    expect(
+      FactoryBot.build(:historical_emissions_metric, name: 'metric', unit: 'unit')
+    ).to have(1).errors_on(:unit)
+  end
+
+  it 'should be valid' do
+    expect(FactoryBot.build(:historical_emissions_metric)).to be_valid
+  end
+end


### PR DESCRIPTION
Following existing convention, for historical emissions module, I added metrics with unit data to existing endpoints.

Story: https://www.pivotaltracker.com/story/show/162159118

emissions endpoint:
```
[
  {
    iso_code3: "IDN",
    emissions: [],
    gwp: "AR2",
    location: "Indonesia",
    gas: "All GHG",
    source: "SIGN SMART",
    sector: "Total",
    metric: "Emission per Capita"
  }
]
```
metadata endpoint
```
{
  ...
  metric: [
    {
      id: 1,
      name: "Absolute value",
      unit: "ktCO2e"
    },
    {
      id: 2,
      name: "Emission per GDP",
      unit: "ktCO2e /million Rupiahs"
    },
    {
      id: 3,
      name: "Emission per Capita",
      unit: "tCO2e /Capita"
    }
  ]
}
```

We also now prevent to import data if the record unit is different for the same metric. That is not happending currently, but all data values withing the metric should have the same unit. Otherwise we would need to apply dynamic conversion.


