### PR TITLE
Fix cw-components version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "compression-webpack-plugin": "1.0.0",
     "core-js": "2.5.3",
     "css-loader": "0.28.7",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.20.0",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.21.0",
     "directory-named-webpack-plugin": "4.0.0",
     "dotenv": "4.0.0",
     "es6-promise": "^4.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,9 +2644,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.20.0":
-  version "1.20.0"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/6f7c419292d7458a4950f309a202a2388e425b96"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.21.0":
+  version "1.21.0"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/6bb790297c8862a380b99ddeb895bfb2ea4ab8dc"
   dependencies:
     d3-format "1.3.0"
     d3-hierarchy "^1.1.8"


### PR DESCRIPTION
`1.20.0` has a faulty guard clause which is causing Indonesia page crash on staging, update the version of cw-components to non-faulty one.