### PR TITLE
Feature/adaptation included

### DIFF
--- a/app/controllers/api/v1/indicators_controller.rb
+++ b/app/controllers/api/v1/indicators_controller.rb
@@ -1,13 +1,16 @@
 module Api
   module V1
     class IndicatorsController < ApiController
+      # rubocop:disable AbcSize
       def index
         indicators = ::Indicator.all
+        indicators = indicators.where(code: codes) if codes
         indicators = indicators.where(section: sections) if sections
 
         values = ::IndicatorValue.includes(:location, :indicator)
         values = values.where(locations: {iso_code3: locations}) if locations
         values = values.where(indicators: {section: sections}) if sections
+        values = values.where(indicators: {code: codes}) if codes
 
         respond_to do |format|
           format.json do
@@ -28,6 +31,7 @@ module Api
           end
         end
       end
+      # rubocop:enable AbcSize
 
       private
 
@@ -37,6 +41,10 @@ module Api
 
       def sections
         params[:section].presence && params[:section].split(',')
+      end
+
+      def codes
+        params[:code].presence && params[:code].split(',')
       end
     end
   end

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -17,6 +17,6 @@
 #
 
 class Indicator < ApplicationRecord
-  validates_presence_of :name, :code, :section, :unit
+  validates_presence_of :name, :code, :section
   validates :code, uniqueness: true
 end

--- a/app/services/import_indicators.rb
+++ b/app/services/import_indicators.rb
@@ -79,7 +79,7 @@ class ImportIndicators
         location: Location.find_by(iso_code3: row[:geoid]),
         indicator: Indicator.find_by(code: row[:ind_code]),
         source: row[:source],
-        values: [{value: row[:value]}]
+        values: [{value: row[:value]&.titleize}]
       )
     end
   end

--- a/app/services/import_indicators.rb
+++ b/app/services/import_indicators.rb
@@ -2,7 +2,7 @@ class ImportIndicators
   include ClimateWatchEngine::CSVImporter
 
   headers indicators: [:indicator, :unit],
-          indicator_values: [:geoid, :ind_code, :category, :source],
+          indicator_values: [:geoid, :ind_code, :source],
           adaptation_included: [:geoid, :ind_code, :source, :value]
 
   INDICATORS_FILEPATH = "#{CW_FILES_PREFIX}indicators/indicators.csv".freeze

--- a/app/services/import_indicators.rb
+++ b/app/services/import_indicators.rb
@@ -2,7 +2,8 @@ class ImportIndicators
   include ClimateWatchEngine::CSVImporter
 
   headers indicators: [:indicator, :unit],
-          indicator_values: [:geoid, :ind_code, :category, :source]
+          indicator_values: [:geoid, :ind_code, :category, :source],
+          adaptation_included: [:geoid, :ind_code, :source, :value]
 
   INDICATORS_FILEPATH = "#{CW_FILES_PREFIX}indicators/indicators.csv".freeze
   INDICATOR_VALUE_FILEPATHS = %W(
@@ -12,6 +13,7 @@ class ImportIndicators
     #{CW_FILES_PREFIX}indicators/pc_energy.csv
     #{CW_FILES_PREFIX}indicators/vulnerability_adaptivity.csv
   ).freeze
+  ADAPTATION_INCLUDED_FILEPATH = "#{CW_FILES_PREFIX}indicators/adaptation_included.csv".freeze
 
   def call
     return unless all_headers_valid?
@@ -19,8 +21,8 @@ class ImportIndicators
     ActiveRecord::Base.transaction do
       cleanup
 
-      import_indicators(indicators_csv)
-
+      import_indicators
+      import_adaptation_included
       indicator_values_csv_hash.each do |filepath, csv|
         import_indicator_values(csv, filepath)
       end
@@ -37,6 +39,9 @@ class ImportIndicators
   def all_headers_valid?
     [
       valid_headers?(indicators_csv, INDICATORS_FILEPATH, headers[:indicators]),
+      valid_headers?(
+        adapt_included_csv, ADAPTATION_INCLUDED_FILEPATH, headers[:adaptation_included]
+      ),
       indicator_values_csv_hash.map do |filepath, csv|
         valid_headers?(csv, filepath, headers[:indicator_values])
       end
@@ -47,19 +52,34 @@ class ImportIndicators
     @indicators_csv ||= S3CSVReader.read(INDICATORS_FILEPATH)
   end
 
+  def adapt_included_csv
+    @adapt_included_csv ||= S3CSVReader.read(ADAPTATION_INCLUDED_FILEPATH)
+  end
+
   def indicator_values_csv_hash
     @indicator_values_csv_hash ||= INDICATOR_VALUE_FILEPATHS.reduce({}) do |acc, filepath|
       acc.merge(filepath => S3CSVReader.read(filepath))
     end
   end
 
-  def import_indicators(csv)
-    import_each_with_logging(csv, INDICATORS_FILEPATH) do |row|
+  def import_indicators
+    import_each_with_logging(indicators_csv, INDICATORS_FILEPATH) do |row|
       Indicator.create!(
         section: section(row),
         code: row[:ind_code],
         name: row[:indicator],
         unit: row[:unit]
+      )
+    end
+  end
+
+  def import_adaptation_included
+    import_each_with_logging(adapt_included_csv, ADAPTATION_INCLUDED_FILEPATH) do |row|
+      IndicatorValue.create!(
+        location: Location.find_by(iso_code3: row[:geoid]),
+        indicator: Indicator.find_by(code: row[:ind_code]),
+        source: row[:source],
+        values: row[:value]
       )
     end
   end

--- a/app/services/import_indicators.rb
+++ b/app/services/import_indicators.rb
@@ -79,7 +79,7 @@ class ImportIndicators
         location: Location.find_by(iso_code3: row[:geoid]),
         indicator: Indicator.find_by(code: row[:ind_code]),
         source: row[:source],
-        values: row[:value]
+        values: [{value: row[:value]}]
       )
     end
   end

--- a/config/data_uploader.yml
+++ b/config/data_uploader.yml
@@ -39,6 +39,7 @@ platforms:
           - pc_energy
           - pc_agriculture
           - vulnerability_adaptivity
+          - adaptation_included
       - name: metadata
         importer: ImportDataSources
         datasets:

--- a/db/migrate/20181204173655_remove_unit_not_null_contraint_from_indicators.rb
+++ b/db/migrate/20181204173655_remove_unit_not_null_contraint_from_indicators.rb
@@ -1,0 +1,5 @@
+class RemoveUnitNotNullContraintFromIndicators < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :indicators, :unit, true, ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_30_131424) do
+ActiveRecord::Schema.define(version: 2018_12_04_173655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -192,7 +192,7 @@ ActiveRecord::Schema.define(version: 2018_11_30_131424) do
     t.string "section", null: false
     t.string "code", null: false
     t.string "name", null: false
-    t.string "unit", null: false
+    t.string "unit"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["code"], name: "index_indicators_on_code", unique: true

--- a/spec/controllers/api/v1/indicators_controller_spec.rb
+++ b/spec/controllers/api/v1/indicators_controller_spec.rb
@@ -64,6 +64,13 @@ describe Api::V1::IndicatorsController, type: :controller do
         expect(response_json['indicators'].length).to eq(1)
         expect(response_json['values'].length).to eq(2)
       end
+
+      it 'filters indicators and values by code' do
+        get :index, params: {code: 'pop_total'}, format: :json
+        expect(response_json['indicators'].length).to eq(1)
+        expect(response_json['indicators'][0]['code']).to eq('pop_total')
+        expect(response_json['values'].length).to eq(2)
+      end
     end
   end
 end

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -7,12 +7,6 @@ RSpec.describe Indicator, type: :model do
     ).to have(1).errors_on(:section)
   end
 
-  it 'should be invalid when unit not present' do
-    expect(
-      FactoryBot.build(:indicator, unit: nil)
-    ).to have(1).errors_on(:unit)
-  end
-
   it 'should be invalid when name not present' do
     expect(
       FactoryBot.build(:indicator, name: nil)

--- a/spec/services/import_indicators_spec.rb
+++ b/spec/services/import_indicators_spec.rb
@@ -111,7 +111,6 @@ RSpec.describe ImportIndicators do
 
     it 'has errors on row' do
       importer.call
-      puts importer.errors
       expect(importer.errors.length).to eq(1)
       expect(importer.errors.first).to include(type: :invalid_row)
     end

--- a/spec/services/import_indicators_spec.rb
+++ b/spec/services/import_indicators_spec.rb
@@ -8,6 +8,7 @@ correct_files = {
     agriculture,area_harvested,Harvested Area of Paddy,ha
     energy,capacity,Installed capacity,MW
     adaptation,Adap_1,Mineral water sources,index
+    adaptation,Adap_13,Adaptation included,text
   END_OF_CSV
   "#{CW_FILES_PREFIX}indicators/socioeconomics.csv" => <<~END_OF_CSV,
     geoid,source,ind_code,category,2010,2011
@@ -28,6 +29,11 @@ correct_files = {
   "#{CW_FILES_PREFIX}indicators/vulnerability_adaptivity.csv" => <<~END_OF_CSV,
     source,geoid,ind_code,category,2011,2014
     SIDIK,ID.AC,Adap_1,0.8,0.8
+  END_OF_CSV
+  "#{CW_FILES_PREFIX}indicators/adaptation_included.csv" => <<~END_OF_CSV,
+    Source,geoid,ind_code,value
+    CAITIDNa,ID.AC,Adap_13,No
+    CAITIDNa,ID.BA,Adap_13,Yes
   END_OF_CSV
 }
 missing_headers_files = correct_files.merge(
@@ -66,11 +72,11 @@ RSpec.describe ImportIndicators do
     end
 
     it 'Creates new indicators' do
-      expect { subject }.to change { Indicator.count }.by(5)
+      expect { subject }.to change { Indicator.count }.by(6)
     end
 
     it 'Creates new indicator values' do
-      expect { subject }.to change { IndicatorValue.count }.by(5)
+      expect { subject }.to change { IndicatorValue.count }.by(7)
     end
   end
 
@@ -100,11 +106,12 @@ RSpec.describe ImportIndicators do
     end
 
     it 'does not create any indicator value with missing location' do
-      expect { importer.call }.to change { IndicatorValue.count }.by(4)
+      expect { importer.call }.to change { IndicatorValue.count }.by(6)
     end
 
     it 'has errors on row' do
       importer.call
+      puts importer.errors
       expect(importer.errors.length).to eq(1)
       expect(importer.errors.first).to include(type: :invalid_row)
     end


### PR DESCRIPTION
Importing missing adaptation included values. The values for this indicator are different because we are not grouping by year this time and this is just simple text: "Yes", "No". To be consistent with the rest of the indicators I decided to keep them in similar form in `values` column so the response may look quite overcomplicated

```
{
  indicator_code: "Adap_13",
  location: "Aceh",
  location_iso_code3: "ID.AC",
  category: null,
  values: [
    {
      value: "No"
    }
  ],
  source: "CAITIDNa"
}
```

because other for other indicators is like
```
values: [
{
  year: "2010",
  value: 238500
},
{
  year: "2011",
  value: 242000
},
```

We can also **filter indicators by code** from now on like `api/v1/indicators?code=Adap_13`

Please run migrations as I had to remove not null constraint from indicator's unit.

`bundle exec rake db:migrate`
`bundle exec rake db:admin_boilerplate:create`

To import data:
`bundle exec rake indicators:import`
or import all
`bundle exec rake db:import`