### PR TITLE
Fix if condition for rendering energy chart

### DIFF
--- a/app/javascript/app/pages/national-context/socioeconomic/energy/energy-selectors.js
+++ b/app/javascript/app/pages/national-context/socioeconomic/energy/energy-selectors.js
@@ -107,16 +107,21 @@ const findOption = (options, value) =>
 
 const getFieldSelected = field => state => {
   const { query } = state.location;
-  if (field === CATEGORIES_QUERY_NAME && !query)
+
+  const categoriesField = field === CATEGORIES_QUERY_NAME;
+  const categoriesInQuery = query && query[CATEGORIES_QUERY_NAME];
+  const indicatorInQuery = query && query[INDICATOR_QUERY_NAME];
+
+  if (categoriesField && !query)
     return getDefaults(state)[field] &&
       getDefaults(state)[field][INDICATOR_CODE];
-  if (
-    field === CATEGORIES_QUERY_NAME &&
-      query[INDICATOR_QUERY_NAME] &&
-      !query[CATEGORIES_QUERY_NAME]
-  ) {
+  if (categoriesField && indicatorInQuery && !categoriesInQuery) {
     return getDefaults(state)[field] &&
       getDefaults(state)[field][query[INDICATOR_QUERY_NAME]];
+  }
+  if (categoriesField && !categoriesInQuery) {
+    return getDefaults(state)[field] &&
+      getDefaults(state)[field][INDICATOR_CODE];
   }
   if (!query || !query[field]) return getDefaults(state)[field];
   const queryValue = query[field];


### PR DESCRIPTION
This PR fixes problem occurring on socioeconomics page that crashes the page when changing indicators for charts other than Energy.
The issue was in fact in the if clause in energy selectors.