### PR TITLE
Add climate plans

### DIFF
--- a/app/javascript/app/components/nav-nested-menu/nav-nested-menu-component.jsx
+++ b/app/javascript/app/components/nav-nested-menu/nav-nested-menu-component.jsx
@@ -56,6 +56,7 @@ class NavNestedMenuComponent extends PureComponent {
         <Child
           className={cx(styles.links, { [styles.open]: open })}
           opened={open}
+          onItemClick={() => this.setState({ open: !open })}
         />
       </React.Fragment>
 ) : null;

--- a/app/javascript/app/components/nav/nav-component.jsx
+++ b/app/javascript/app/components/nav/nav-component.jsx
@@ -17,7 +17,7 @@ const renderActions = () => {
 
 class Nav extends PureComponent {
   render() {
-    const { routes, theme, content } = this.props;
+    const { routes, theme, content, provinceInfo, locale } = this.props;
     return (
       <nav className={theme.nav}>
         {routes.map(route => {
@@ -29,6 +29,22 @@ class Nav extends PureComponent {
                 className={cx(styles.link, theme.link)}
                 Child={route.Child}
               />
+            );
+          }
+          if (route.province) {
+            const isoCode = provinceInfo && provinceInfo.iso_code3;
+            return (
+              <NavLink
+                exact={route.exact || false}
+                className={cx(styles.link, theme.link)}
+                key={route.slug}
+                to={`/${locale}/regions/${isoCode}/${route.slug}`}
+                activeClassName={styles.active}
+                onTouchStart={undefined}
+                onMouseDown={undefined}
+              >
+                {getTranslation(content, route.slug, 'title')}
+              </NavLink>
             );
           }
           return (
@@ -54,9 +70,11 @@ class Nav extends PureComponent {
 Nav.propTypes = {
   routes: PropTypes.array.isRequired,
   theme: PropTypes.shape({ nav: PropTypes.string, link: PropTypes.string }),
-  content: PropTypes.object.isRequired
+  content: PropTypes.object.isRequired,
+  provinceInfo: PropTypes.object,
+  locale: PropTypes.string
 };
 
-Nav.defaultProps = { theme: {} };
+Nav.defaultProps = { theme: {}, provinceInfo: null, locale: '' };
 
 export default Nav;

--- a/app/javascript/app/components/nav/nav.js
+++ b/app/javascript/app/components/nav/nav.js
@@ -1,8 +1,16 @@
 import { connect } from 'react-redux';
+import { provincesDetails } from 'selectors/provinces-selectors';
+import { getLocale } from 'selectors/translation-selectors';
 import Component from './nav-component';
 
-const mapStateToProps = ({ SectionsContent }) => ({
-  content: SectionsContent.data
-});
+const mapStateToProps = state => {
+  const { SectionsContent } = state;
+  return {
+    content: SectionsContent.data,
+    provinceInfo: provincesDetails(state) &&
+      provincesDetails(state).provinceInfo,
+    locale: getLocale(state)
+  };
+};
 
 export default connect(mapStateToProps, null)(Component);

--- a/app/javascript/app/components/regions-select/regions-select-component.jsx
+++ b/app/javascript/app/components/regions-select/regions-select-component.jsx
@@ -7,12 +7,19 @@ import styles from 'components/nav-nested-menu/nav-nested-menu-styles';
 
 class RegionsSelect extends PureComponent {
   render() {
-    const { provinces, opened, className, onItemClick } = this.props;
+    const {
+      provinces,
+      opened,
+      className,
+      onItemClick,
+      activeProvince
+    } = this.props;
 
     return opened && (
     <React.Fragment>
       <ResultsList
         list={provinces}
+        activeProvince={activeProvince}
         className={cx(className, styles.regionsList)}
         emptyDataMsg="No results"
         handleMouseItemEnter={() => {
@@ -30,7 +37,8 @@ RegionsSelect.propTypes = {
   provinces: PropTypes.array,
   opened: PropTypes.bool,
   className: PropTypes.string,
-  onItemClick: PropTypes.func
+  onItemClick: PropTypes.func,
+  activeProvince: PropTypes.string
 };
 
 RegionsSelect.defaultProps = {
@@ -38,7 +46,8 @@ RegionsSelect.defaultProps = {
   opened: false,
   className: '',
   onItemClick: () => {
-  }
+  },
+  activeProvince: ''
 };
 
 export default RegionsSelect;

--- a/app/javascript/app/components/regions-select/regions-select-component.jsx
+++ b/app/javascript/app/components/regions-select/regions-select-component.jsx
@@ -7,21 +7,19 @@ import styles from 'components/nav-nested-menu/nav-nested-menu-styles';
 
 class RegionsSelect extends PureComponent {
   render() {
-    const { provinces, opened, className } = this.props;
+    const { provinces, opened, className, onItemClick } = this.props;
 
     return opened && (
     <React.Fragment>
       <ResultsList
         list={provinces}
         className={cx(className, styles.regionsList)}
-        opened
         emptyDataMsg="No results"
         handleMouseItemEnter={() => {
             }}
         handleMouseItemLeave={() => {
             }}
-        handleClick={() => {
-            }}
+        handleClick={onItemClick}
       />
     </React.Fragment>
       );
@@ -31,9 +29,16 @@ class RegionsSelect extends PureComponent {
 RegionsSelect.propTypes = {
   provinces: PropTypes.array,
   opened: PropTypes.bool,
-  className: PropTypes.string
+  className: PropTypes.string,
+  onItemClick: PropTypes.func
 };
 
-RegionsSelect.defaultProps = { provinces: [], opened: false, className: '' };
+RegionsSelect.defaultProps = {
+  provinces: [],
+  opened: false,
+  className: '',
+  onItemClick: () => {
+  }
+};
 
 export default RegionsSelect;

--- a/app/javascript/app/components/regions-select/regions-select-selectors.js
+++ b/app/javascript/app/components/regions-select/regions-select-selectors.js
@@ -9,7 +9,7 @@ const getParsedProvinces = createSelector(getProvinces, provinces => {
   return provinces.map(province => ({
     value: province.iso_code3,
     label: province.wri_standard_name,
-    path: `/regions/${province.iso_code3}`
+    path: `/regions/${province.iso_code3}/regions-ghg-emissions`
   }));
 });
 

--- a/app/javascript/app/components/regions-select/regions-select-selectors.js
+++ b/app/javascript/app/components/regions-select/regions-select-selectors.js
@@ -1,6 +1,7 @@
 import { createStructuredSelector, createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import get from 'lodash/get';
+import { getProvince } from 'selectors/provinces-selectors';
 
 const DEFAULT_SECTION = 'regions-ghg-emissions';
 
@@ -32,5 +33,6 @@ const getParsedProvinces = createSelector([ getProvinces, getSection ], (
   });
 
 export const getProvincesData = createStructuredSelector({
-  provinces: getParsedProvinces
+  provinces: getParsedProvinces,
+  activeProvince: getProvince
 });

--- a/app/javascript/app/components/regions-select/regions-select-selectors.js
+++ b/app/javascript/app/components/regions-select/regions-select-selectors.js
@@ -1,17 +1,35 @@
 import { createStructuredSelector, createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
+import get from 'lodash/get';
+
+const DEFAULT_SECTION = 'regions-ghg-emissions';
 
 const getProvinces = ({ provinces }) => provinces && provinces.data || null;
+const getLocation = ({ location }) => location && location;
 
-const getParsedProvinces = createSelector(getProvinces, provinces => {
-  if (!provinces || isEmpty(provinces)) return [];
+const getSection = createSelector(getLocation, location => {
+  if (!location) return null;
 
-  return provinces.map(province => ({
-    value: province.iso_code3,
-    label: province.wri_standard_name,
-    path: `/regions/${province.iso_code3}/regions-ghg-emissions`
-  }));
+  return get(location, 'payload.region')
+    ? get(location, 'payload.section')
+    : '';
 });
+
+const getParsedProvinces = createSelector([ getProvinces, getSection ], (
+  provinces,
+  section
+) =>
+  {
+    if (!provinces || isEmpty(provinces)) return [];
+
+    const provinceSection = section || DEFAULT_SECTION;
+
+    return provinces.map(province => ({
+      value: province.iso_code3,
+      label: province.wri_standard_name,
+      path: `/regions/${province.iso_code3}/${provinceSection}`
+    }));
+  });
 
 export const getProvincesData = createStructuredSelector({
   provinces: getParsedProvinces

--- a/app/javascript/app/components/results-list/results-list-component.jsx
+++ b/app/javascript/app/components/results-list/results-list-component.jsx
@@ -17,14 +17,17 @@ const ResultsList = props => {
     theme,
     handleMouseItemEnter,
     handleMouseItemLeave,
-    handleClick
+    handleClick,
+    activeProvince
   } = props;
   return (
     <ul className={cx(styles.resultsList, className, theme.resultsList)}>
       {
         list.length > 0 ? list.map(item => (
           <li
-            className={cx(styles.listItem, theme.listItem)}
+            className={cx(styles.listItem, theme.listItem, {
+                [styles.active]: activeProvince === item.value
+              })}
             onMouseEnter={() => handleMouseItemEnter(item.value)}
             onMouseLeave={handleMouseItemLeave}
             key={item.value}
@@ -60,7 +63,8 @@ ResultsList.propTypes = {
   theme: PropTypes.object,
   handleMouseItemEnter: PropTypes.func,
   handleMouseItemLeave: PropTypes.func,
-  handleClick: PropTypes.func
+  handleClick: PropTypes.func,
+  activeProvince: PropTypes.string
 };
 
 ResultsList.defaultProps = {
@@ -69,6 +73,7 @@ ResultsList.defaultProps = {
   emptyDataMsg: 'No data',
   theme: {},
   className: '',
+  activeProvince: '',
   handleMouseItemEnter() {
   },
   handleMouseItemLeave() {

--- a/app/javascript/app/components/results-list/results-list-styles.scss
+++ b/app/javascript/app/components/results-list/results-list-styles.scss
@@ -17,6 +17,10 @@
   }
 }
 
+.active {
+  text-decoration: underline;
+}
+
 .link {
   font-family: $font-family-1;
   color: $midnight-blue;

--- a/app/javascript/app/layouts/sections/sections-component.jsx
+++ b/app/javascript/app/layouts/sections/sections-component.jsx
@@ -31,9 +31,10 @@ class Section extends PureComponent {
   }
 
   render() {
-    const { route, section, content } = this.props;
+    const { route, section, content, provinceInfo } = this.props;
 
-    const title = getTranslation(content, route.slug, 'title');
+    const title = getTranslation(content, route.slug, 'title') 
+      || provinceInfo && provinceInfo.wri_standard_name;
     const description = getTranslation(content, route.slug, 'description');
     const subsectionTitle = getTranslation(content, section.slug, 'title');
     const subsectionDescription = getTranslation(content, section.slug, 'description');
@@ -60,7 +61,12 @@ class Section extends PureComponent {
 Section.propTypes = {
   route: PropTypes.object.isRequired,
   section: PropTypes.object.isRequired,
-  content: PropTypes.object.isRequired
+  content: PropTypes.object.isRequired,
+  provinceInfo: PropTypes.object
+}
+
+Section.defaultProps = {
+  provinceInfo: null
 }
 
 export default Section;

--- a/app/javascript/app/layouts/sections/sections.js
+++ b/app/javascript/app/layouts/sections/sections.js
@@ -1,8 +1,10 @@
 import { connect } from 'react-redux';
+import { provincesDetails } from 'selectors/provinces-selectors';
 
 import PlanningComponent from './sections-component';
 
-const mapStateToProps = ({ location, SectionsContent }) => {
+const mapStateToProps = state => {
+  const { location, SectionsContent } = state;
   const route = location.routesMap[location.type];
   const { section: currentSectionSlug } = location.payload;
   let section = null;
@@ -11,7 +13,13 @@ const mapStateToProps = ({ location, SectionsContent }) => {
     section = route.sections.find(s => s.slug === currentSectionSlug) ||
       defaultSection;
   }
-  return { route, section, content: SectionsContent.data };
+  return {
+    route,
+    section,
+    content: SectionsContent.data,
+    provinceInfo: provincesDetails(state) &&
+      provincesDetails(state).provinceInfo
+  };
 };
 
 export default connect(mapStateToProps, null)(PlanningComponent);

--- a/app/javascript/app/pages/national-context/climate-funding/climate-funding-selectors.js
+++ b/app/javascript/app/pages/national-context/climate-funding/climate-funding-selectors.js
@@ -1,7 +1,7 @@
 import { createStructuredSelector, createSelector } from 'reselect';
 import { isEmpty } from 'lodash';
 import { getTranslatedContent } from 'selectors/translation-selectors';
-import { lowerDeburr } from 'utils/utils';
+import { createTextSearchSelector } from 'selectors/util-selectors';
 
 const getQuery = ({ location }) => location && (location.query || null);
 const getData = ({ FundingOportunities }) =>
@@ -11,24 +11,6 @@ const getSearch = createSelector(getQuery, query => {
   if (!query || !query.search) return null;
   return query.search;
 });
-
-export const getFilteredDataBySearch = createSelector([ getData, getSearch ], (
-  data,
-  search
-) =>
-  {
-    if (!data || isEmpty(data)) return [];
-    if (!search || isEmpty(search)) return data;
-    const updatedData = data;
-    return updatedData.filter(
-      d => Object.keys(d).some(key => {
-        if (Object.prototype.hasOwnProperty.call(d, key) && d[key] !== null) {
-          return lowerDeburr(String(d[key])).indexOf(lowerDeburr(search)) > -1;
-        }
-        return false;
-      })
-    );
-  });
 
 export const getLinkableColumnsSchema = createSelector(getData, data => {
   if (!data || isEmpty(data)) return null;
@@ -43,7 +25,7 @@ const requestedTranslations = [
 ];
 
 export const mapStateToProps = createStructuredSelector({
-  data: getFilteredDataBySearch,
+  data: createTextSearchSelector(getData, getSearch),
   titleLinks: getLinkableColumnsSchema,
   translations: getTranslatedContent(requestedTranslations)
 });

--- a/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-actions.js
+++ b/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-actions.js
@@ -1,0 +1,4 @@
+import { createAction } from 'redux-tools';
+import { REGIONS } from 'router';
+
+export const updateFiltersSelected = createAction(REGIONS);

--- a/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-component.jsx
+++ b/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-component.jsx
@@ -44,7 +44,7 @@ class ClimateSectoralPlan extends PureComponent {
             <InfoDownloadToolbox
               className={{ buttonWrapper: styles.buttonWrapper }}
               slugs=""
-              downloadUri="funding_opportunities"
+              downloadUri="province/climate_plans"
               infoTooltipdata="Table data information"
               downloadTooltipdata="Download table data in .csv"
             />

--- a/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-component.jsx
+++ b/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-component.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import SectionTitle from 'components/section-title';
 import ClimatePlansProvider from 'providers/climate-plans-provider';
-import { Switch, Input, Table } from 'cw-components';
+import { Switch, Input, Table, NoContent } from 'cw-components';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
 import styles from './climate-sectoral-plan-styles.scss';
 
@@ -16,6 +16,7 @@ class ClimateSectoralPlan extends PureComponent {
     const { translations, onSearchChange, data } = this.props;
 
     const defaultColumns = [ 'sector', 'sub_sector', 'mitigation_activities' ];
+    const hasContent = data && data.length > 0;
 
     return (
       <div className={styles.page}>
@@ -49,14 +50,20 @@ class ClimateSectoralPlan extends PureComponent {
             />
           </div>
           <div className={styles.tableContainer}>
-            <Table
-              data={data && data}
-              defaultColumns={defaultColumns}
-              ellipsisColumns={[ 'description' ]}
-              emptyValueLabel="Not specified"
-              horizontalScroll
-              parseMarkdown
-            />
+            {
+              hasContent
+                ? (
+                  <Table
+                    data={data && data}
+                    defaultColumns={defaultColumns}
+                    ellipsisColumns={[ 'description' ]}
+                    emptyValueLabel="Not specified"
+                    horizontalScroll
+                    parseMarkdown
+                  />
+)
+                : <NoContent minHeight={330} message="No data found" />
+            }
           </div>
         </div>
         <ClimatePlansProvider />

--- a/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-component.jsx
+++ b/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-component.jsx
@@ -1,0 +1,81 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import SectionTitle from 'components/section-title';
+import ClimatePlansProvider from 'providers/climate-plans-provider';
+import { Switch, Input, Table } from 'cw-components';
+import InfoDownloadToolbox from 'components/info-download-toolbox';
+import styles from './climate-sectoral-plan-styles.scss';
+
+const options = [
+  { name: 'Development Plans', value: 'development-plans', disabled: true },
+  { name: 'Climate Plans', value: 'climate-plans' }
+];
+
+class ClimateSectoralPlan extends PureComponent {
+  render() {
+    const { translations, onSearchChange, data } = this.props;
+
+    const defaultColumns = [ 'sector', 'sub_sector', 'mitigation_activities' ];
+
+    return (
+      <div className={styles.page}>
+        <SectionTitle
+          title={translations.title}
+          description={translations.description}
+        />
+        <div className={styles.switch}>
+          <Switch
+            options={options}
+            selectedOption="climate-plans"
+            theme={{
+              wrapper: styles.wrapper,
+              checkedOption: styles.checkedOption
+            }}
+          />
+        </div>
+        <div>
+          <div className={styles.actions}>
+            <Input
+              onChange={onSearchChange}
+              placeholder="Search"
+              theme={styles}
+            />
+            <InfoDownloadToolbox
+              className={{ buttonWrapper: styles.buttonWrapper }}
+              slugs=""
+              downloadUri="funding_opportunities"
+              infoTooltipdata="Table data information"
+              downloadTooltipdata="Download table data in .csv"
+            />
+          </div>
+          <div className={styles.tableContainer}>
+            <Table
+              data={data && data}
+              defaultColumns={defaultColumns}
+              ellipsisColumns={[ 'description' ]}
+              emptyValueLabel="Not specified"
+              horizontalScroll
+              parseMarkdown
+            />
+          </div>
+        </div>
+        <ClimatePlansProvider />
+      </div>
+    );
+  }
+}
+
+ClimateSectoralPlan.propTypes = {
+  translations: PropTypes.object,
+  onSearchChange: PropTypes.func,
+  data: PropTypes.array
+};
+
+ClimateSectoralPlan.defaultProps = {
+  translations: {},
+  onSearchChange: () => {
+  },
+  data: []
+};
+
+export default ClimateSectoralPlan;

--- a/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-selectors.js
+++ b/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-selectors.js
@@ -1,8 +1,7 @@
 import { createStructuredSelector, createSelector } from 'reselect';
 import { getTranslation } from 'utils/translations';
 import { getProvince } from 'selectors/provinces-selectors';
-import isEmpty from 'lodash/isEmpty';
-import { lowerDeburr } from 'utils/utils';
+import { createTextSearchSelector } from 'selectors/util-selectors';
 
 export const getSectionsContent = ({ SectionsContent }) =>
   SectionsContent && SectionsContent.data;
@@ -17,23 +16,6 @@ const getSearch = createSelector(getQuery, query => {
   return query.search;
 });
 
-export const getFilteredDataBySearch = createSelector(
-  [ getClimateSectoralPlan, getSearch ],
-  (data, search) => {
-    if (!data || isEmpty(data)) return [];
-    if (!search || isEmpty(search)) return data;
-    const updatedData = data;
-    return updatedData.filter(
-      d => Object.keys(d).some(key => {
-        if (Object.prototype.hasOwnProperty.call(d, key) && d[key] !== null) {
-          return lowerDeburr(String(d[key])).indexOf(lowerDeburr(search)) > -1;
-        }
-        return false;
-      })
-    );
-  }
-);
-
 const getTranslatedContent = createSelector([ getSectionsContent ], data => {
   if (!data) return null;
   const sectionSlug = 'climate-sectoral-plan-section';
@@ -46,5 +28,5 @@ const getTranslatedContent = createSelector([ getSectionsContent ], data => {
 export const getClimateSectoralPlanData = createStructuredSelector({
   translations: getTranslatedContent,
   provinceIso: getProvince,
-  data: getFilteredDataBySearch
+  data: createTextSearchSelector(getClimateSectoralPlan, getSearch)
 });

--- a/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-selectors.js
+++ b/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-selectors.js
@@ -1,0 +1,50 @@
+import { createStructuredSelector, createSelector } from 'reselect';
+import { getTranslation } from 'utils/translations';
+import { getProvince } from 'selectors/provinces-selectors';
+import isEmpty from 'lodash/isEmpty';
+import { lowerDeburr } from 'utils/utils';
+
+export const getSectionsContent = ({ SectionsContent }) =>
+  SectionsContent && SectionsContent.data;
+
+const getQuery = ({ location }) => location && (location.query || null);
+
+const getClimateSectoralPlan = ({ climatePlans }) =>
+  climatePlans && climatePlans.data;
+
+const getSearch = createSelector(getQuery, query => {
+  if (!query || !query.search) return null;
+  return query.search;
+});
+
+export const getFilteredDataBySearch = createSelector(
+  [ getClimateSectoralPlan, getSearch ],
+  (data, search) => {
+    if (!data || isEmpty(data)) return [];
+    if (!search || isEmpty(search)) return data;
+    const updatedData = data;
+    return updatedData.filter(
+      d => Object.keys(d).some(key => {
+        if (Object.prototype.hasOwnProperty.call(d, key) && d[key] !== null) {
+          return lowerDeburr(String(d[key])).indexOf(lowerDeburr(search)) > -1;
+        }
+        return false;
+      })
+    );
+  }
+);
+
+const getTranslatedContent = createSelector([ getSectionsContent ], data => {
+  if (!data) return null;
+  const sectionSlug = 'climate-sectoral-plan-section';
+  return {
+    title: getTranslation(data, sectionSlug, 'title'),
+    description: getTranslation(data, sectionSlug, 'description')
+  };
+});
+
+export const getClimateSectoralPlanData = createStructuredSelector({
+  translations: getTranslatedContent,
+  provinceIso: getProvince,
+  data: getFilteredDataBySearch
+});

--- a/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-styles.scss
+++ b/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-styles.scss
@@ -1,0 +1,42 @@
+@import '~styles/settings.scss';
+@import '~styles/layout.scss';
+
+$borderRadius: 4px;
+
+.page {
+  @include row();
+
+  margin-top: $gutter-padding;
+}
+
+.actions {
+  @include columns($columns: (4,2));
+}
+
+.input {
+  border: solid 1px $border-color;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
+}
+
+.buttonWrapper {
+  max-width: 100px;
+}
+
+.tableContainer {
+  margin: 50px 0 100px;
+}
+
+.switch {
+  margin-bottom: 50px;
+}
+
+.wrapper {
+  border-radius: $borderRadius;
+  color: $marine-blue;
+}
+
+.checkedOption {
+  border-radius: $borderRadius;
+  color: $white;
+  background-color: $dark-blue;
+}

--- a/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan.js
+++ b/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan.js
@@ -1,0 +1,35 @@
+import { connect } from 'react-redux';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { getClimateSectoralPlanData } from './climate-sectoral-plan-selectors';
+import Component from './climate-sectoral-plan-component';
+
+import * as actions from './climate-sectoral-plan-actions';
+
+const mapStateToProps = getClimateSectoralPlanData;
+
+class ClimateSectoralPlanContainer extends PureComponent {
+  onSearchChange = value => {
+    const { updateFiltersSelected, query, provinceIso } = this.props;
+
+    updateFiltersSelected({
+      section: 'climate-sectoral-plan',
+      region: provinceIso,
+      query: { ...query, search: value }
+    });
+  };
+
+  render() {
+    return <Component {...this.props} onSearchChange={this.onSearchChange} />;
+  }
+}
+
+ClimateSectoralPlanContainer.propTypes = {
+  updateFiltersSelected: PropTypes.func.isRequired,
+  query: PropTypes.object,
+  provinceIso: PropTypes.string
+};
+
+ClimateSectoralPlanContainer.defaultProps = { query: {}, provinceIso: '' };
+
+export default connect(mapStateToProps, actions)(ClimateSectoralPlanContainer);

--- a/app/javascript/app/pages/regions/regions-ghg-emissions/regions-ghg-emissions-component.jsx
+++ b/app/javascript/app/pages/regions/regions-ghg-emissions/regions-ghg-emissions-component.jsx
@@ -1,10 +1,16 @@
 import React, { PureComponent } from 'react';
 // import PropTypes from 'prop-types';
+import ClimatePlansProvider from 'providers/climate-plans-provider';
 import styles from './regions-ghg-emissions-styles.scss';
 
 class RegionsGhgEmissions extends PureComponent {
   render() {
-    return <p className={styles.text}>The RegionsGhgEmissions section</p>;
+    return (
+      <React.Fragment>
+        <p className={styles.text}>The RegionsGhgEmissions section</p>
+        <ClimatePlansProvider />
+      </React.Fragment>
+    );
   }
 }
 

--- a/app/javascript/app/providers/climate-plans-provider/climate-plans-provider-actions.js
+++ b/app/javascript/app/providers/climate-plans-provider/climate-plans-provider-actions.js
@@ -7,12 +7,12 @@ export const fetchClimatePlansFail = createAction('fetchClimatePlansFail');
 
 export const fetchClimatePlans = createThunkAction(
   'fetchClimatePlans',
-  isoCode => (dispatch, state) => {
+  params => (dispatch, state) => {
     const { climatePlans } = state();
     if (climatePlans && !climatePlans.loading) {
       dispatch(fetchClimatePlansInit());
       INDOAPI
-        .get('province/climate_plans', { location: isoCode })
+        .get('province/climate_plans', params)
         .then((data = {}) => {
           dispatch(fetchClimatePlansReady(data));
         })

--- a/app/javascript/app/providers/climate-plans-provider/climate-plans-provider-actions.js
+++ b/app/javascript/app/providers/climate-plans-provider/climate-plans-provider-actions.js
@@ -1,0 +1,25 @@
+import { createAction, createThunkAction } from 'redux-tools';
+import { INDOAPI } from 'services/api';
+
+export const fetchClimatePlansInit = createAction('fetchClimatePlansInit');
+export const fetchClimatePlansReady = createAction('fetchClimatePlansReady');
+export const fetchClimatePlansFail = createAction('fetchClimatePlansFail');
+
+export const fetchClimatePlans = createThunkAction(
+  'fetchClimatePlans',
+  isoCode => (dispatch, state) => {
+    const { climatePlans } = state();
+    if (climatePlans && !climatePlans.loading) {
+      dispatch(fetchClimatePlansInit());
+      INDOAPI
+        .get('province/climate_plans', { location: isoCode })
+        .then((data = {}) => {
+          dispatch(fetchClimatePlansReady(data));
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(fetchClimatePlansFail(error && error.message));
+        });
+    }
+  }
+);

--- a/app/javascript/app/providers/climate-plans-provider/climate-plans-provider-reducers.js
+++ b/app/javascript/app/providers/climate-plans-provider/climate-plans-provider-reducers.js
@@ -1,0 +1,22 @@
+import * as actions from './climate-plans-provider-actions';
+
+export const initialState = {
+  loading: false,
+  loaded: false,
+  data: {},
+  error: false
+};
+
+export default {
+  [actions.fetchClimatePlansInit]: state => ({ ...state, loading: true }),
+  [actions.fetchClimatePlansReady]: (state, { payload }) => ({
+    ...state,
+    loading: false,
+    data: payload
+  }),
+  [actions.fetchClimatePlans]: (state, { payload }) => ({
+    ...state,
+    loading: false,
+    error: payload
+  })
+};

--- a/app/javascript/app/providers/climate-plans-provider/climate-plans-provider.js
+++ b/app/javascript/app/providers/climate-plans-provider/climate-plans-provider.js
@@ -1,0 +1,36 @@
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { getProvince } from 'selectors/provinces-selectors';
+import isEqual from 'lodash/isEqual';
+
+import * as actions from './climate-plans-provider-actions';
+import reducers, { initialState } from './climate-plans-provider-reducers';
+
+class ClimatePlansProvider extends PureComponent {
+  componentDidMount() {
+    const { fetchClimatePlans, province } = this.props;
+    fetchClimatePlans(province);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { fetchClimatePlans, province } = this.props;
+    const { province: prevParams } = prevProps;
+
+    if (!isEqual(prevParams, province)) fetchClimatePlans(province);
+  }
+
+  render() {
+    return null;
+  }
+}
+
+ClimatePlansProvider.propTypes = {
+  fetchClimatePlans: PropTypes.func.isRequired,
+  province: PropTypes.object.isRequired
+};
+
+export const reduxModule = { actions, reducers, initialState };
+
+const mapStateToProps = state => ({ province: getProvince(state) });
+export default connect(mapStateToProps, actions)(ClimatePlansProvider);

--- a/app/javascript/app/providers/climate-plans-provider/climate-plans-provider.js
+++ b/app/javascript/app/providers/climate-plans-provider/climate-plans-provider.js
@@ -1,36 +1,12 @@
-import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 import { getProvince } from 'selectors/provinces-selectors';
-import isEqual from 'lodash/isEqual';
 
+import LocalizedProvider from 'providers/localized-provider';
 import * as actions from './climate-plans-provider-actions';
 import reducers, { initialState } from './climate-plans-provider-reducers';
 
-class ClimatePlansProvider extends PureComponent {
-  componentDidMount() {
-    const { fetchClimatePlans, province } = this.props;
-    fetchClimatePlans(province);
-  }
-
-  componentDidUpdate(prevProps) {
-    const { fetchClimatePlans, province } = this.props;
-    const { province: prevParams } = prevProps;
-
-    if (!isEqual(prevParams, province)) fetchClimatePlans(province);
-  }
-
-  render() {
-    return null;
-  }
-}
-
-ClimatePlansProvider.propTypes = {
-  fetchClimatePlans: PropTypes.func.isRequired,
-  province: PropTypes.object.isRequired
-};
+const mapDispatchToProps = { fetchData: actions.fetchClimatePlans };
+const mapStateToProps = state => ({ params: { location: getProvince(state) } });
 
 export const reduxModule = { actions, reducers, initialState };
-
-const mapStateToProps = state => ({ province: getProvince(state) });
-export default connect(mapStateToProps, actions)(ClimatePlansProvider);
+export default connect(mapStateToProps, mapDispatchToProps)(LocalizedProvider);

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -23,6 +23,7 @@ import {
 } from 'providers/emission-activities-provider';
 import { reduxModule as adaptation } from 'providers/adaptation-provider';
 import { reduxModule as locations } from 'providers/locations-provider';
+import { reduxModule as climatePlans } from 'providers/climate-plans-provider';
 
 // Router
 import router from './router';
@@ -41,7 +42,8 @@ const providerReducers = {
   indicators: handleModule(indicators),
   emissionActivities: handleModule(emissionActivites),
   adaptation: handleModule(adaptation),
-  provinces: handleModule(locations)
+  provinces: handleModule(locations),
+  climatePlans: handleModule(climatePlans)
 };
 
 export default combineReducers({

--- a/app/javascript/app/router/router.js
+++ b/app/javascript/app/router/router.js
@@ -49,7 +49,7 @@ export const routes = {
     slug: 'regions',
     label: 'Province Module',
     link: '/:locale/regions',
-    path: '/:locale?/regions/:region?',
+    path: '/:locale?/regions/:region?/:section?',
     module: '/regions',
     component: 'layouts/sections/sections',
     sections: RegionsSections,

--- a/app/javascript/app/router/sections/regions.js
+++ b/app/javascript/app/router/sections/regions.js
@@ -1,20 +1,24 @@
 export default [
   {
     slug: 'regions-ghg-emissions',
-    path: '/:locale/regions/:region/ghg-emissions',
+    path: '/:locale/regions/:region/regions-ghg-emissions',
     exact: true,
+    province: true,
     default: true
   },
   {
     slug: 'sectoral-circumstances',
-    path: '/:locale/regions/:region/sectoral-circumstances'
+    path: '/:locale/regions/:region/sectoral-circumstances',
+    province: true
   },
   {
     slug: 'vulnerability-adaptivity',
-    path: '/:locale/regions/:region/vulnerability-adaptivity'
+    path: '/:locale/regions/:region/vulnerability-adaptivity',
+    province: true
   },
   {
     slug: 'climate-sectoral-plan',
-    path: '/:locale/regions/:region/sectoral-plan'
+    path: '/:locale/regions/:region/sectoral-plan',
+    province: true
   }
 ];

--- a/app/javascript/app/selectors/provinces-selectors.js
+++ b/app/javascript/app/selectors/provinces-selectors.js
@@ -1,0 +1,3 @@
+import get from 'lodash/get';
+
+export const getProvince = ({ location }) => get(location, 'payload.region');

--- a/app/javascript/app/selectors/provinces-selectors.js
+++ b/app/javascript/app/selectors/provinces-selectors.js
@@ -1,3 +1,21 @@
 import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+import { createSelector, createStructuredSelector } from 'reselect';
 
 export const getProvince = ({ location }) => get(location, 'payload.region');
+
+export const getLocations = ({ provinces }) =>
+  provinces && provinces.data || null;
+
+export const getProvinceDetails = createSelector(
+  [ getProvince, getLocations ],
+  (provinceIso, provinces) => {
+    if (!provinceIso || !provinces || isEmpty(provinces)) return null;
+
+    return provinces.find(province => province.iso_code3 === provinceIso);
+  }
+);
+
+export const provincesDetails = createStructuredSelector({
+  provinceInfo: getProvinceDetails
+});

--- a/app/javascript/app/selectors/translation-selectors.js
+++ b/app/javascript/app/selectors/translation-selectors.js
@@ -2,8 +2,6 @@ import { getTranslation } from 'utils/translations';
 import { createSelector } from 'reselect';
 import get from 'lodash/get';
 
-import { DEFAULT_LANGUAGE } from 'constants/languages';
-
 const getSectionsContent = ({ SectionsContent }) =>
   SectionsContent && SectionsContent.data;
 
@@ -21,5 +19,4 @@ export const getTranslatedContent = requestedTranslations =>
     return translatedKeys;
   });
 
-export const getLocale = ({ location }) =>
-  get(location, 'payload.locale', DEFAULT_LANGUAGE);
+export const getLocale = ({ location }) => get(location, 'payload.locale');

--- a/app/javascript/app/selectors/util-selectors.js
+++ b/app/javascript/app/selectors/util-selectors.js
@@ -1,0 +1,17 @@
+import { createSelector } from 'reselect';
+import { lowerDeburr } from 'utils/utils';
+import isEmpty from 'lodash/isEmpty';
+
+export const createTextSearchSelector = (getData, getSearch) => createSelector([ getData, getSearch ], (data, search) => {
+    if (!data || isEmpty(data)) return [];
+    if (!search || isEmpty(search)) return data;
+    const updatedData = data;
+    return updatedData.filter(
+      d => Object.keys(d).some(key => {
+        if (Object.prototype.hasOwnProperty.call(d, key) && d[key] !== null) {
+          return lowerDeburr(String(d[key])).indexOf(lowerDeburr(search)) > -1;
+        }
+        return false;
+      })
+    );
+  });

--- a/config/content_management_sections.yml
+++ b/config/content_management_sections.yml
@@ -111,3 +111,18 @@ sections:
   - name: CLIMATE_GOALS_sectoral-information
     slug: sectoral-information
     order: 37
+  - name: PROVINCES_emissions_and_targets
+    slug: regions-ghg-emissions
+    order: 38
+  - name: PROVINCES_sectoral_circumstances
+    slug: sectoral-circumstances
+    order: 39
+  - name: PROVINCES_vulnerability_adaptivity
+    slug: vulnerability-adaptivity
+    order: 40
+  - name: PROVINCES_climate_sectoral_plan
+    slug: climate-sectoral-plan
+    order: 41
+  - name: PROVINCES_climate-sectoral-plan-section
+    slug: climate-sectoral-plan-section
+    order: 42

--- a/config/translations/en.yml
+++ b/config/translations/en.yml
@@ -110,3 +110,18 @@ en:
   sectoral-activity-indicator-label:
     title: Indicator
     description:
+  regions-ghg-emissions:
+    title: GHG emissions and targets
+    description:
+  sectoral-circumstances:
+    title: Sectoral circumstances
+    description:
+  vulnerability-adaptivity:
+    title: Vulnerability and adaptivity
+    description:
+  climate-sectoral-plan:
+    title: Climate sectoral plan
+    description:
+  climate-sectoral-plan-section:
+    title: Climate and development plans by sector
+    description: Lorem ipsum dolor sit amet

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "compression-webpack-plugin": "1.0.0",
     "core-js": "2.5.3",
     "css-loader": "0.28.7",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.24.0",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.27.0",
     "directory-named-webpack-plugin": "4.0.0",
     "dotenv": "4.0.0",
     "es6-promise": "^4.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,8 +74,8 @@
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.0.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.2.0.tgz#7941c5b2d8060e06f9601d6be7c223eef906d5d8"
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.2.2.tgz#44e10fc24e33af524488b716cdaee5360ea8ed1e"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
@@ -323,8 +323,8 @@ ajv@^5.0.0, ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
     json-schema-traverse "^0.3.0"
 
 ajv@^6.0.1, ajv@^6.1.0, ajv@^6.5.5:
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.1.tgz#6360f5ed0d80f232cc2b294c362d5dc2e538dd61"
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.2.tgz#caceccf474bf3fc3ce3b147443711a24063cc30d"
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1819,12 +1819,12 @@ caniuse-api@^2.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000187, caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000916"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000916.tgz#44556ba3f7360a4e103950fc58cc98b74d253da1"
+  version "1.0.30000923"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000923.tgz#0724b5fbd7f9fe424060b788b11e6b8d77102deb"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000718, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000864:
-  version "1.0.30000916"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000916.tgz#3428d3f529f0a7b2bfaaec65e796037bdd433aab"
+  version "1.0.30000923"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000923.tgz#148f9bda508024b5ce957b463ae2e8302b451bb2"
 
 capitalize@1.0.0:
   version "1.0.0"
@@ -2195,8 +2195,8 @@ colormin@^1.0.5:
     has "^1.0.1"
 
 colors@>=0.6.2, colors@^1.1.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.2.tgz#2df8ff573dfbf255af562f8ce7181d6b971a359b"
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
 
 colors@~1.1.2:
   version "1.1.2"
@@ -2259,7 +2259,7 @@ concat-map@0.0.1:
 
 concat-stream@^1.4.7, concat-stream@^1.5.0, concat-stream@^1.6.0:
   version "1.6.2"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  resolved "http://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
     buffer-from "^1.0.0"
     inherits "^2.0.3"
@@ -2319,7 +2319,7 @@ contains-path@^0.1.0:
 
 content-disposition@0.5.2:
   version "0.5.2"
-  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
+  resolved "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
 content-type@~1.0.4:
   version "1.0.4"
@@ -2371,8 +2371,8 @@ core-js@^1.0.0:
   resolved "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
 core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.0.tgz#1e30793e9ee5782b307e37ffa22da0eacddd84d4"
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.1.tgz#87416ae817de957a3f249b3b5ca475d4aaed6042"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2648,9 +2648,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.24.0":
-  version "1.24.0"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/a8ef13a89716f62201c2d21015546e52eee5d5aa"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.27.0":
+  version "1.27.0"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/5998e2951b561e05a5668c717f729b8a48acf4ad"
   dependencies:
     d3-format "1.3.0"
     d3-hierarchy "^1.1.8"
@@ -2658,6 +2658,7 @@ currently-unhandled@^0.4.1:
     react-addons-transition-group "15.6.2"
     react-collapse "4.0.3"
     react-dom-factories "1.0.0"
+    react-markdown "^4.0.4"
     react-modal "3.5.1"
     react-motion "0.5.2"
     react-responsive "5.0.0"
@@ -2782,8 +2783,8 @@ dashdash@^1.12.0:
     assert-plus "^1.0.0"
 
 date-fns@^1.27.2:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -3055,7 +3056,7 @@ domhandler@2.1:
   dependencies:
     domelementtype "1"
 
-domhandler@^2.3.0:
+domhandler@^2.3.0, domhandler@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
   dependencies:
@@ -3136,8 +3137,8 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47:
-  version "1.3.88"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.88.tgz#f36ab32634f49ef2b0fdc1e82e2d1cc17feb29e7"
+  version "1.3.96"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.96.tgz#25770ec99b8b07706dedf3a5f43fa50cb54c4f9a"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -3864,8 +3865,8 @@ findup-sync@^2.0.0:
     resolve-dir "^1.0.1"
 
 fined@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fined/-/fined-1.1.0.tgz#b37dc844b76a2f5e7081e884f7c0ae344f153476"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/fined/-/fined-1.1.1.tgz#95d88ff329123dd1a6950fdfcd321f746271e01f"
   dependencies:
     expand-tilde "^2.0.2"
     is-plain-object "^2.0.3"
@@ -3874,8 +3875,8 @@ fined@^1.0.1:
     parse-filepath "^1.0.1"
 
 flagged-respawn@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.0.tgz#4e79ae9b2eb38bf86b3bb56bf3e0a56aa5fcabd7"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.1.tgz#e7de6f1279ddd9ca9aac8a5971d618606b3aab41"
 
 flat-cache@^1.2.1:
   version "1.3.4"
@@ -4203,7 +4204,7 @@ global-modules-path@^2.1.0:
 
 global-modules@^0.2.3:
   version "0.2.3"
-  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-0.2.3.tgz#ea5a3bed42c6d6ce995a4f8a1269b5dae223828d"
+  resolved "http://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz#ea5a3bed42c6d6ce995a4f8a1269b5dae223828d"
   dependencies:
     global-prefix "^0.1.4"
     is-windows "^0.2.0"
@@ -4218,7 +4219,7 @@ global-modules@^1.0.0:
 
 global-prefix@^0.1.4:
   version "0.1.5"
-  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
+  resolved "http://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
   dependencies:
     homedir-polyfill "^1.0.0"
     ini "^1.3.4"
@@ -4551,6 +4552,16 @@ html-tags@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
 
+html-to-react@^1.3.3:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.3.4.tgz#647b3a54fdec73a6461864b129fb0d1eec7d4589"
+  dependencies:
+    domhandler "^2.4.2"
+    escape-string-regexp "^1.0.5"
+    htmlparser2 "^3.10.0"
+    lodash.camelcase "^4.3.0"
+    ramda "^0.26"
+
 html-webpack-plugin@2.29.0:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-2.29.0.tgz#e987f421853d3b6938c8c4c8171842e5fd17af23"
@@ -4562,7 +4573,7 @@ html-webpack-plugin@2.29.0:
     pretty-error "^2.0.2"
     toposort "^1.0.0"
 
-htmlparser2@^3.8.3, htmlparser2@^3.9.2:
+htmlparser2@^3.10.0, htmlparser2@^3.8.3, htmlparser2@^3.9.2:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.0.tgz#5f5e422dcf6119c0d983ed36260ce9ded0bee464"
   dependencies:
@@ -4863,7 +4874,7 @@ is-absolute@^1.0.0:
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
-  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  resolved "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
   dependencies:
     kind-of "^3.0.2"
 
@@ -4928,7 +4939,7 @@ is-ci@^1.0.10:
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  resolved "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
   dependencies:
     kind-of "^3.0.2"
 
@@ -5268,8 +5279,8 @@ jquery@>=3.0.0:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
 
 js-base64@^2.1.8, js-base64@^2.1.9:
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.9.tgz#748911fb04f48a60c4771b375cac45a80df11c03"
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.0.tgz#42255ba183ab67ce59a0dee640afdc00ab5ae93e"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -5908,6 +5919,12 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+mdast-add-list-metadata@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz#95e73640ce2fc1fa2dcb7ec443d09e2bfe7db4cf"
+  dependencies:
+    unist-util-visit-parents "1.1.2"
+
 mdast-util-compact@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/mdast-util-compact/-/mdast-util-compact-1.0.2.tgz#c12ebe16fffc84573d3e19767726de226e95f649"
@@ -6139,8 +6156,8 @@ minipass@^2.2.1, minipass@^2.3.4:
     yallist "^3.0.0"
 
 minizlib@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.1.tgz#6734acc045a46e61d596a43bb9d9cd326e19cc42"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
   dependencies:
     minipass "^2.2.1"
 
@@ -6219,7 +6236,7 @@ multicast-dns@^6.0.1:
 
 multimatch@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
+  resolved "http://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
   dependencies:
     array-differ "^1.0.0"
     array-union "^1.0.1"
@@ -6235,8 +6252,8 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 nan@^2.3.2, nan@^2.9.2:
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
 
 nanomatch@^1.2.1, nanomatch@^1.2.9:
   version "1.2.13"
@@ -6908,7 +6925,7 @@ pascalcase@^0.1.1:
 
 path-browserify@0.0.0:
   version "0.0.0"
-  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
+  resolved "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
 
 path-case@^1.1.0:
   version "1.1.2"
@@ -6946,7 +6963,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
-path-parse@^1.0.5:
+path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
@@ -7695,8 +7712,8 @@ postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.10, postcss@^6.0.11, postcss@^6.0.1
     supports-color "^5.4.0"
 
 postcss@^7.0.1, postcss@^7.0.2:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.6.tgz#6dcaa1e999cdd4a255dcd7d4d9547f4ca010cdc2"
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.7.tgz#2754d073f77acb4ef08f1235c36c5721a7201614"
   dependencies:
     chalk "^2.4.1"
     source-map "^0.6.1"
@@ -7848,8 +7865,8 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 psl@^1.1.24, psl@^1.1.28:
-  version "1.1.29"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
+  version "1.1.31"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
 
 public-encrypt@^4.0.0:
   version "4.0.3"
@@ -7945,6 +7962,10 @@ ramda@^0.24.1:
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
 
+ramda@^0.26:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+
 random-string@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/random-string/-/random-string-0.2.0.tgz#a46e4375352beda9a0d7b0d19ed6d321ecd1d82d"
@@ -7985,7 +8006,7 @@ raw-body@2.3.3:
 
 raw-loader@0.5.1:
   version "0.5.1"
-  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
+  resolved "http://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
@@ -8062,6 +8083,18 @@ react-hot-loader@4.3.4:
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+
+react-markdown@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.0.4.tgz#bdc882bc3eb4dfac45d57bfe58d8f482c5a85a64"
+  dependencies:
+    html-to-react "^1.3.3"
+    mdast-add-list-metadata "1.0.1"
+    prop-types "^15.6.1"
+    remark-parse "^5.0.0"
+    unified "^6.1.5"
+    unist-util-visit "^1.3.0"
+    xtend "^4.0.1"
 
 react-modal@3.5.1:
   version "3.5.1"
@@ -8177,8 +8210,8 @@ react-transition-group@^1.2.0:
     warning "^3.0.0"
 
 react-transition-group@^2.2.1:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.0.tgz#70bca0e3546102c4dc5cf3f5f57f73447cce6874"
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.2.tgz#9457166a9ba6ce697a3e1b076b3c049b9fb2c408"
   dependencies:
     dom-helpers "^3.3.1"
     loose-envify "^1.4.0"
@@ -8298,8 +8331,8 @@ readable-stream@^1.0.33, readable-stream@~1.1.9:
     string_decoder "~0.10.x"
 
 readable-stream@^3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.0.6.tgz#351302e4c68b5abd6a2ed55376a7f9a25be3057a"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.1.0.tgz#19c2e9c1ce43507c53f6eefbcf1ee3d4aaa786f5"
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -8738,8 +8771,8 @@ reselect@3.0.1:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
 
 resize-observer-polyfill@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -8749,7 +8782,7 @@ resolve-cwd@^2.0.0:
 
 resolve-dir@^0.1.0:
   version "0.1.1"
-  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"
+  resolved "http://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"
   dependencies:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
@@ -8796,10 +8829,10 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
 resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.9.0.tgz#a14c6fdfa8f92a7df1d996cb7105fa744658ea06"
   dependencies:
-    path-parse "^1.0.5"
+    path-parse "^1.0.6"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -9257,8 +9290,8 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz#a59efc09784c2a5bada13cfeaf5c75dd214044d2"
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz#81c0ce8f21474756148bbb5f3bfc0f36bf15d76e"
 
 spdy-transport@^2.0.18:
   version "2.1.1"
@@ -9295,17 +9328,17 @@ split-string@^3.0.1, split-string@^3.0.2:
 
 split2@^0.2.1:
   version "0.2.1"
-  resolved "https://registry.yarnpkg.com/split2/-/split2-0.2.1.tgz#02ddac9adc03ec0bb78c1282ec079ca6e85ae900"
+  resolved "http://registry.npmjs.org/split2/-/split2-0.2.1.tgz#02ddac9adc03ec0bb78c1282ec079ca6e85ae900"
   dependencies:
     through2 "~0.6.1"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  resolved "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.15.2.tgz#c946d6bd9b1a39d0e8635763f5242d6ed6dcb629"
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.0.tgz#1d4963a2fbffe58050aa9084ca20be81741c07de"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -9411,7 +9444,7 @@ string-similarity@1.2.0:
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  resolved "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   dependencies:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
@@ -9659,7 +9692,7 @@ sugarss@^1.0.0:
 
 supports-color@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  resolved "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
 supports-color@^3.2.3:
   version "3.2.3"
@@ -9998,7 +10031,7 @@ tslib@^1.9.0:
 
 tty-browserify@0.0.0:
   version "0.0.0"
-  resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
+  resolved "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -10086,7 +10119,7 @@ unidecode@0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/unidecode/-/unidecode-0.1.8.tgz#efbb301538bc45246a9ac8c559d72f015305053e"
 
-unified@^6.0.0:
+unified@^6.0.0, unified@^6.1.5:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
   dependencies:
@@ -10152,13 +10185,17 @@ unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
 
+unist-util-visit-parents@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz#f6e3afee8bdbf961c0e6f028ea3c0480028c3d06"
+
 unist-util-visit-parents@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz#63fffc8929027bee04bfef7d2cce474f71cb6217"
   dependencies:
     unist-util-is "^2.1.2"
 
-unist-util-visit@^1.1.0:
+unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.0.tgz#1cb763647186dc26f5e1df5db6bd1e48b3cc2fb1"
   dependencies:
@@ -10344,8 +10381,8 @@ vfile-location@^2.0.0:
   resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.4.tgz#2a5e7297dd0d9e2da4381464d04acc6b834d3e55"
 
 vfile-message@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.2.tgz#0f8a62584c5dff0f81760531b8e34f3cea554ebc"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
   dependencies:
     unist-util-stringify-position "^1.1.1"
 
@@ -10364,7 +10401,7 @@ viewport-dimensions@^0.2.0:
 
 vm-browserify@0.0.4:
   version "0.0.4"
-  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
+  resolved "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
 


### PR DESCRIPTION
This PR continues creating routing for provinces sections + adds first part of the Climate Sectoral Plan section (`Climate Plans` in Switch)

Some translations were added so run `bundle exec rake db:update_translations`, also reinstall node_modules as cw-components were updated.

![image](https://user-images.githubusercontent.com/6136899/50356540-3b2c7980-054a-11e9-96f8-8877c5fe3666.png)
