### PR TITLE
Translate table headers

### DIFF
--- a/app/javascript/app/pages/national-context/climate-funding/climate-funding-component.jsx
+++ b/app/javascript/app/pages/national-context/climate-funding/climate-funding-component.jsx
@@ -1,23 +1,28 @@
 import React, { PureComponent } from 'react';
-import SectionTitle from 'components/section-title';
-import { Input, Table } from 'cw-components';
-import FundingOportunitiesProvider from 'providers/funding-oportunities-provider';
 import PropTypes from 'prop-types';
+import { Input, Table } from 'cw-components';
+
+import { renameKeys } from 'utils';
+import SectionTitle from 'components/section-title';
+import FundingOportunitiesProvider from 'providers/funding-oportunities-provider';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
+
 import styles from './climate-funding-styles.scss';
 
 class ClimateFunding extends PureComponent {
   render() {
     const { t, data, titleLinks, onSearchChange } = this.props;
-    const { title, description } = t('pages.national-context.climate-funding');
+    const nt = key => t(`pages.national-context.climate-funding.${key}`);
 
-    const defaultColumns = [
-      'project_name',
-      'mode_of_support',
-      'sectors_and_topics',
-      'description',
-      'website_link'
-    ];
+    const tableHeaders = nt('table-headers', {});
+    tableHeaders.website_link = 'website_link';
+    const defaultColumns = Object.values(tableHeaders);
+
+    const tableData = data.map(d => renameKeys(d, tableHeaders));
+
+    const title = nt('title');
+    const description = nt('description');
+
     return (
       <div className={styles.page}>
         <SectionTitle title={title} description={description} />
@@ -40,12 +45,12 @@ class ClimateFunding extends PureComponent {
           </div>
           <div className={styles.tableContainer}>
             <Table
-              data={data && data}
+              data={tableData && tableData}
               defaultColumns={defaultColumns}
-              ellipsisColumns={[ 'description' ]}
+              ellipsisColumns={[ tableHeaders.description ]}
               emptyValueLabel={t('common.table-empty-value')}
               horizontalScroll
-              hiddenColumnHeaderLabels={[ 'website_link' ]}
+              hiddenColumnHeaderLabels={[ tableHeaders.website_link ]}
               titleLinks={data && titleLinks}
             />
           </div>

--- a/app/javascript/app/pages/regions/climate-sectoral-plan/climate-plans/climate-plans-component.jsx
+++ b/app/javascript/app/pages/regions/climate-sectoral-plan/climate-plans/climate-plans-component.jsx
@@ -1,28 +1,52 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ClimatePlansProvider from 'providers/climate-plans-provider';
 import { Input, Table, NoContent } from 'cw-components';
+
+import { renameKeys } from 'utils';
+import ClimatePlansProvider from 'providers/climate-plans-provider';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
+
 import styles from './climate-plans-styles.scss';
 
 class ClimatePlans extends PureComponent {
-  render() {
-    const { data, t, handleFilterChange, provinceIso } = this.props;
-    const defaultColumns = [ 'sector', 'sub_sector', 'mitigation_activities' ];
+  renderTable(nt) {
+    const { data, t } = this.props;
     const hasContent = data && data.length > 0;
+
+    if (!hasContent) {
+      return <NoContent minHeight={330} message={t('common.table-no-data')} />;
+    }
+
+    const tableHeaders = nt('climate-plans-table-headers', {});
+    const defaultColumns = Object.values(tableHeaders);
+
+    const tableData = data.map(d => renameKeys(d, tableHeaders));
+
+    return (
+      <Table
+        data={tableData}
+        defaultColumns={defaultColumns}
+        ellipsisColumns={[ tableHeaders.description ]}
+        emptyValueLabel={t('common.table-empty-value')}
+        horizontalScroll
+        parseMarkdown
+      />
+    );
+  }
+
+  render() {
+    const { t, handleFilterChange, provinceIso } = this.props;
+    // namespaced t
+    const nt = key => t(`pages.regions.climate-sectoral-plan.${key}`);
 
     const options = [
       {
-        label: t(
-          'pages.regions.climate-sectoral-plan.development-plans-csv-download'
-        ),
+        label: nt('csv-download'),
         value: 'csv',
         url: 'province/climate_plans'
       },
       {
-        label: t(
-          'pages.regions.climate-sectoral-plan.development-plans-pdf-download'
-        ),
+        label: nt('pdf-download'),
         value: 'pdf',
         url: `http://wri-sites.s3.amazonaws.com/climatewatch.org/www.climatewatch.org/indonesia/documents/climate-plans/${provinceIso}.pdf`
       }
@@ -33,9 +57,7 @@ class ClimatePlans extends PureComponent {
         <div className={styles.actions}>
           <Input
             onChange={value => handleFilterChange('search', value)}
-            placeholder={t(
-              'pages.regions.climate-sectoral-plan.search-placeholder'
-            )}
+            placeholder={nt('search-placeholder')}
             theme={styles}
           />
           <InfoDownloadToolbox
@@ -47,25 +69,7 @@ class ClimatePlans extends PureComponent {
           />
         </div>
         <div className={styles.tableContainer}>
-          {
-            hasContent
-              ? (
-                <Table
-                  data={data && data}
-                  defaultColumns={defaultColumns}
-                  ellipsisColumns={[ 'description' ]}
-                  emptyValueLabel={t('common.table-empty-value')}
-                  horizontalScroll
-                  parseMarkdown
-                />
-)
-              : (
-                <NoContent
-                  minHeight={330}
-                  message={t('common.table-no-data')}
-                />
-)
-          }
+          {this.renderTable(nt)}
         </div>
         <ClimatePlansProvider />
       </div>

--- a/app/javascript/app/pages/regions/climate-sectoral-plan/development-plans/development-plans-component.jsx
+++ b/app/javascript/app/pages/regions/climate-sectoral-plan/development-plans/development-plans-component.jsx
@@ -1,32 +1,52 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import DevelopmentPlansProvider from 'providers/development-plans-provider';
 import { Input, Table, NoContent } from 'cw-components';
+
+import { renameKeys } from 'utils';
+import DevelopmentPlansProvider from 'providers/development-plans-provider';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
+
 import styles from '../climate-plans/climate-plans-styles';
 
 class DevelopmentPlans extends PureComponent {
-  render() {
-    const { data, handleFilterChange, t, provinceIso } = this.props;
-    const defaultColumns = [
-      'sector',
-      'RPJMD_period',
-      'supportive_policy_direction_in_RPJMD'
-    ];
+  renderTable(nt) {
+    const { data, t } = this.props;
     const hasContent = data && data.length > 0;
 
+    if (!hasContent) {
+      return <NoContent minHeight={330} message={t('common.table-no-data')} />;
+    }
+
+    const tableHeaders = nt('development-plans-table-headers', {});
+    const defaultColumns = Object.values(tableHeaders);
+
+    const tableData = data.map(d => renameKeys(d, tableHeaders));
+
+    return (
+      <Table
+        data={tableData}
+        defaultColumns={defaultColumns}
+        setColumnWidth={() => 250}
+        ellipsisColumns={[ tableHeaders.description ]}
+        emptyValueLabel={t('common.table-empty-value')}
+        horizontalScroll
+        parseMarkdown
+      />
+    );
+  }
+
+  render() {
+    const { handleFilterChange, t, provinceIso } = this.props;
+    // namespaced t
+    const nt = key => t(`pages.regions.climate-sectoral-plan.${key}`);
     const options = [
       {
-        label: t(
-          'pages.regions.climate-sectoral-plan.development-plans-csv-download'
-        ),
+        label: nt('csv-download'),
         value: 'csv',
         url: 'province/development_plans'
       },
       {
-        label: t(
-          'pages.regions.climate-sectoral-plan.development-plans-pdf-download'
-        ),
+        label: nt('pdf-download'),
         value: 'pdf',
         url: `http://wri-sites.s3.amazonaws.com/climatewatch.org/www.climatewatch.org/indonesia/documents/development-plans/${provinceIso}.pdf`
       }
@@ -37,9 +57,7 @@ class DevelopmentPlans extends PureComponent {
         <div className={styles.actions}>
           <Input
             onChange={value => handleFilterChange('search', value)}
-            placeholder={t(
-              'pages.regions.climate-sectoral-plan.search-placeholder'
-            )}
+            placeholder={nt('search-placeholder')}
             theme={styles}
           />
           <InfoDownloadToolbox
@@ -51,26 +69,7 @@ class DevelopmentPlans extends PureComponent {
           />
         </div>
         <div className={styles.tableContainer}>
-          {
-            hasContent
-              ? (
-                <Table
-                  data={data && data}
-                  defaultColumns={defaultColumns}
-                  setColumnWidth={() => 250}
-                  ellipsisColumns={[ 'description' ]}
-                  emptyValueLabel={t('common.table-empty-value')}
-                  horizontalScroll
-                  parseMarkdown
-                />
-)
-              : (
-                <NoContent
-                  minHeight={330}
-                  message={t('common.table-no-data')}
-                />
-)
-          }
+          {this.renderTable(nt)}
         </div>
         <DevelopmentPlansProvider />
       </div>

--- a/app/javascript/app/utils/utils.js
+++ b/app/javascript/app/utils/utils.js
@@ -2,3 +2,11 @@ import deburr from 'lodash/deburr';
 
 export const lowerDeburr = string => deburr(string.toLowerCase());
 export const upperDeburr = string => deburr(String(string).toUpperCase());
+
+export const renameKeys = (obj, newKeys) => {
+  const keyValues = Object.keys(obj).map(key => {
+    const newKey = newKeys[key] || key;
+    return { [newKey]: obj[key] };
+  });
+  return Object.assign({}, ...keyValues);
+};

--- a/config/locales/en/app/pages/national_context.yml
+++ b/config/locales/en/app/pages/national_context.yml
@@ -57,3 +57,8 @@ en:
           description: ''
           view-more-link: View more
           search-placeholder: Search
+          table-headers:
+            project_name: Project name
+            mode_of_support: Mode of support
+            sectors_and_topics: Sectors and topics
+            description: Description

--- a/config/locales/en/app/pages/regions.yml
+++ b/config/locales/en/app/pages/regions.yml
@@ -34,5 +34,13 @@ en:
           climate-plans: Climate plans
           search-placeholder: Search
           development-plans-subheader: Supportive Mission statement in RPJMD
-          development-plans-csv-download: Table data (CSV)
-          development-plans-pdf-download: Original file (PDF)
+          csv-download: Table data (CSV)
+          pdf-download: Original file (PDF)
+          development-plans-table-headers:
+            sector: Sector
+            RPJMD_period: RPJMD period
+            supportive_policy_direction_in_RPJMD: Supportive policy direction in RPJMD
+          climate-plans-table-headers:
+            sector: sector
+            sub_sector: Sub sector
+            mitigation_activities: Mitigation activities


### PR DESCRIPTION
Adding translations for table headers in:

- province development plans
- province climate plans
- national context climate funding

When new table component arrives then this method of renaming keys could be changed. I was near to complete this that's why I created this first version.