### PR TITLE
Add download icon to the navbar

### DIFF
--- a/app/javascript/app/components/header/header-component.jsx
+++ b/app/javascript/app/components/header/header-component.jsx
@@ -67,6 +67,7 @@ class Header extends PureComponent {
               <Button
                 onClick={this.handleDownloadClick}
                 theme={{ button: styles.button }}
+                disabled
               >
                 <Icon icon={downloadIcon} />
               </Button>

--- a/app/javascript/app/components/header/header-component.jsx
+++ b/app/javascript/app/components/header/header-component.jsx
@@ -5,6 +5,10 @@ import Nav from 'components/nav';
 import NavNestedMenu from 'components/nav-nested-menu';
 import { NavLink } from 'redux-first-router-link';
 import { LANGUAGES_AVAILABLE } from 'constants/languages';
+import { Icon, Button } from 'cw-components';
+
+import downloadIcon from 'assets/icons/download';
+
 import navStyles from 'components/nav/nav-styles';
 import styles from './header-styles.scss';
 
@@ -13,6 +17,8 @@ class Header extends PureComponent {
     const { onChangeLanguage } = this.props;
     onChangeLanguage(language.value);
   };
+
+  handleDownloadClick = () => window.open('todo', '_blank');
 
   render() {
     const { routes, className, locale } = this.props;
@@ -58,6 +64,12 @@ class Header extends PureComponent {
                 ))}
             </div>
             <div className={styles.rightTabs}>
+              <Button
+                onClick={this.handleDownloadClick}
+                theme={{ button: styles.button }}
+              >
+                <Icon icon={downloadIcon} />
+              </Button>
               <NavNestedMenu
                 key="language"
                 options={LANGUAGES_AVAILABLE}

--- a/app/javascript/app/components/header/header-styles.scss
+++ b/app/javascript/app/components/header/header-styles.scss
@@ -143,3 +143,17 @@ $flag-height: 40px;
 .leftTabs {
   display: flex;
 }
+
+.rightTabs {
+  display: flex;
+  align-items: center;
+  border-left: 1px solid $iron;
+  padding-left: 20px;
+}
+
+.button {
+  width: 50px;
+  box-shadow: none;
+
+  &:hover { box-shadow: none; }
+}

--- a/app/javascript/app/components/header/header-styles.scss
+++ b/app/javascript/app/components/header/header-styles.scss
@@ -154,6 +154,7 @@ $flag-height: 40px;
 .button {
   width: 50px;
   box-shadow: none;
+  border: none;
 
   &:hover { box-shadow: none; }
 }

--- a/app/javascript/app/styles/settings.scss
+++ b/app/javascript/app/styles/settings.scss
@@ -61,6 +61,7 @@ $link-water: #ecf1fa;
 $catskill-white: #e8ecf5;
 $downriver: #0a1941;
 $trout: #50535f;
+$iron: #D1D2D5;
 
 // Theme-colors
 $theme-color: $midnight-blue;

--- a/app/javascript/app/styles/settings.scss
+++ b/app/javascript/app/styles/settings.scss
@@ -61,7 +61,7 @@ $link-water: #ecf1fa;
 $catskill-white: #e8ecf5;
 $downriver: #0a1941;
 $trout: #50535f;
-$iron: #D1D2D5;
+$iron: #d1d2d5;
 
 // Theme-colors
 $theme-color: $midnight-blue;


### PR DESCRIPTION
This PR adds a download data icon to the sticky navbar. It is supposed to download all raw data zipped but since the endpoint isn't ready it is disabled for now.

![image](https://user-images.githubusercontent.com/6136899/52362936-91da0e00-2a39-11e9-8a1b-8140068fdd81.png)
