### PR TITLE
changing supply of primary energy chart to percentage

### DIFF
--- a/app/javascript/app/layouts/sections/sections-styles.scss
+++ b/app/javascript/app/layouts/sections/sections-styles.scss
@@ -3,6 +3,7 @@
 
 .page {
   min-height: calc(100vh - #{$header-height} - #{$footer-height});
+  margin-bottom: 100px;
 }
 
 .section {

--- a/app/javascript/app/pages/climate-goals/overview/overview-styles.scss
+++ b/app/javascript/app/pages/climate-goals/overview/overview-styles.scss
@@ -184,5 +184,4 @@
 
 .timelineContainer {
   background-color: $link-water;
-  margin-bottom: 100px;
 }

--- a/app/javascript/app/pages/national-context/climate-funding/climate-funding-styles.scss
+++ b/app/javascript/app/pages/national-context/climate-funding/climate-funding-styles.scss
@@ -21,5 +21,5 @@
 }
 
 .tableContainer {
-  margin: 50px 0 100px;
+  margin-top: 50px;
 }

--- a/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-styles.scss
+++ b/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-styles.scss
@@ -3,7 +3,6 @@
 
 .mapSection {
   background-color: $link-water;
-  margin-bottom: 50px;
 }
 
 .page {

--- a/app/javascript/app/pages/national-context/socioeconomic/energy/energy-component.jsx
+++ b/app/javascript/app/pages/national-context/socioeconomic/energy/energy-component.jsx
@@ -67,7 +67,7 @@ class Energy extends PureComponent {
               chartData.data &&
               (
                 <Chart
-                  type="line"
+                  type={chartData.type}
                   config={chartData.config}
                   theme={{ legend: styles.legend }}
                   data={chartData.data}

--- a/app/javascript/app/pages/national-context/socioeconomic/energy/energy-selectors.js
+++ b/app/javascript/app/pages/national-context/socioeconomic/energy/energy-selectors.js
@@ -14,8 +14,10 @@ import {
 } from '../population/population-selectors';
 
 const { COUNTRY_ISO } = process.env;
-const INDICATOR_CODE = 'supply_energy';
-const ENERGY_INDICATORS = [ 'supply_energy', 'ins_power', 'elec_ratio' ];
+const SUPPLY_ENERGY_CODE = 'supply_energy';
+const DEFAULT_INDICATOR_CODE = SUPPLY_ENERGY_CODE;
+const ENERGY_INDICATORS = [ SUPPLY_ENERGY_CODE, 'ins_power', 'elec_ratio' ];
+
 const INDICATOR_QUERY_NAME = 'energyInd';
 const CATEGORIES_QUERY_NAME = 'categories';
 
@@ -88,7 +90,7 @@ const getDefaults = createSelector([ getOptions, getDefaultCategories ], (
   defaultCategories
 ) => ({
   [INDICATOR_QUERY_NAME]: options &&
-    options.find(o => o.value === INDICATOR_CODE),
+    options.find(o => o.value === DEFAULT_INDICATOR_CODE),
   [CATEGORIES_QUERY_NAME]: defaultCategories
 }));
 
@@ -104,21 +106,21 @@ const getFieldSelected = field => state => {
 
   if (categoriesField && !query)
     return getDefaults(state)[field] &&
-      getDefaults(state)[field][INDICATOR_CODE];
+      getDefaults(state)[field][DEFAULT_INDICATOR_CODE];
   if (categoriesField && indicatorInQuery && !categoriesInQuery) {
     return getDefaults(state)[field] &&
       getDefaults(state)[field][query[INDICATOR_QUERY_NAME]];
   }
   if (categoriesField && !categoriesInQuery) {
     return getDefaults(state)[field] &&
-      getDefaults(state)[field][INDICATOR_CODE];
+      getDefaults(state)[field][DEFAULT_INDICATOR_CODE];
   }
   if (!query || !query[field]) return getDefaults(state)[field];
   const queryValue = query[field];
 
   const getFilterOptionsForCategories = (s, f) => {
     if (!query[INDICATOR_QUERY_NAME])
-      return getFilterOptions(s)[f][INDICATOR_CODE];
+      return getFilterOptions(s)[f][DEFAULT_INDICATOR_CODE];
     return getFilterOptions(s)[f][query[INDICATOR_QUERY_NAME]];
   };
 
@@ -224,6 +226,10 @@ const getChartData = createSelector(
         d => d.indicator_code === indicator.value
       );
 
+      const chartType = indicator.value === SUPPLY_ENERGY_CODE
+        ? 'percentage'
+        : 'line';
+
       const categories = filteredEnergyDataByIndicator.map(e => ({
         label: capitalize(e.category) || indicator.name,
         value: e.category || indicator.value
@@ -279,7 +285,8 @@ const getChartData = createSelector(
             : value => `${format(',')(value)}`
         },
         dataSelected: legendDataSelected,
-        dataOptions: categories
+        dataOptions: categories,
+        type: chartType
       };
     }
 );

--- a/app/javascript/app/pages/national-context/socioeconomic/energy/energy-selectors.js
+++ b/app/javascript/app/pages/national-context/socioeconomic/energy/energy-selectors.js
@@ -226,9 +226,7 @@ const getChartData = createSelector(
         d => d.indicator_code === indicator.value
       );
 
-      const chartType = indicator.value === SUPPLY_ENERGY_CODE
-        ? 'percentage'
-        : 'line';
+      const chartType = indicator.value === SUPPLY_ENERGY_CODE ? 'bar' : 'line';
 
       const categories = filteredEnergyDataByIndicator.map(e => ({
         label: capitalize(e.category) || indicator.name,
@@ -262,13 +260,15 @@ const getChartData = createSelector(
 
       const configYColumns = yColumns.map(y => ({
         label: y.label,
-        value: `y${capitalize(y.value)}`
+        value: `y${capitalize(y.value)}`,
+        stackId: 'stack'
       }));
 
       const allYColumns = filterOptions[CATEGORIES_QUERY_NAME][indicator.value];
       const configAllYColumns = allYColumns.map(y => ({
         label: y.label,
-        value: `y${capitalize(y.value)}`
+        value: `y${capitalize(y.value)}`,
+        stackId: 'stack'
       }));
 
       return {

--- a/app/javascript/app/pages/regions/climate-sectoral-plan/climate-plans/climate-plans-styles.scss
+++ b/app/javascript/app/pages/regions/climate-sectoral-plan/climate-plans/climate-plans-styles.scss
@@ -18,7 +18,7 @@ $borderRadius: 4px;
 }
 
 .tableContainer {
-  margin: 50px 0 100px;
+  margin-top: 50px;
 }
 
 .actions {

--- a/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-styles.scss
+++ b/app/javascript/app/pages/regions/climate-sectoral-plan/climate-sectoral-plan-styles.scss
@@ -23,7 +23,7 @@ $borderRadius: 4px;
 }
 
 .tableContainer {
-  margin: 50px 0 100px;
+  margin-top: 50px;
 }
 
 .switch {


### PR DESCRIPTION
Changing chart type for the supply of primary energy to a percentage one.

![image](https://user-images.githubusercontent.com/1286444/52562023-6cfce680-2dfd-11e9-9cf3-04b697397c95.png)

There is a problem with data though. The percentage chart is taking the values and computing the percentage by itself. Here the sum for years is not always 100%! I think that is a data mistake, and now the percentage chart is showing different values that come from the API.

![image](https://user-images.githubusercontent.com/1286444/52562390-ac780280-2dfe-11e9-9a5b-2534b5e878a9.png)
