### PR TITLE
webpack: allow to easily test locally linked cw-components

### DIFF
--- a/app/javascript/app/app.jsx
+++ b/app/javascript/app/app.jsx
@@ -1,6 +1,5 @@
 import 'babel-polyfill';
 import 'whatwg-fetch';
-import 'cw-components/dist/main';
 
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -8,6 +7,16 @@ import { Provider } from 'react-redux';
 
 import store from 'app/store';
 import Root from './layouts/root';
+
+// using try catch to get warning if module not found
+// module will not be found if cw-components linked locally using yarn link
+// but we don't have to import in this case
+try {
+  // eslint-disable-next-line global-require
+  require('cw-components/dist/main');
+} catch (err) {
+  console.warn('cw-components/dist/main not found');
+}
 
 const App = ({ data }) => (
   <Provider store={store(data)}>

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -2,15 +2,26 @@
 
 // eslint-disable-next-line
 const dotenv = require('dotenv').config();
+const path = require('path');
 const merge = require('webpack-merge');
+const DuplicatePackageCheckerPlugin = require(
+  'duplicate-package-checker-webpack-plugin'
+);
 const sharedConfig = require('./shared.js');
 const { settings, output } = require('./configuration.js');
 
 module.exports = merge(sharedConfig, {
+  resolve: {
+    alias: {
+      react: path.resolve('./node_modules/react'),
+      'react-dom': path.resolve('./node_modules/react-dom')
+    }
+  },
   devtool: '#eval-source-map',
   mode: 'development',
   stats: { errorDetails: true },
   output: { pathinfo: true },
+  plugins: [ new DuplicatePackageCheckerPlugin() ],
   devServer: {
     clientLogLevel: 'none',
     https: settings.dev_server.https,

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
+    "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "eslint": "4.19.1",
     "eslint-config-airbnb": "17.0.0",
     "eslint-config-prettier": "2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2166,7 +2166,7 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -3705,6 +3705,16 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+duplicate-package-checker-webpack-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/duplicate-package-checker-webpack-plugin/-/duplicate-package-checker-webpack-plugin-3.0.0.tgz#78bb89e625fa7cf8c2a59c53f62b495fda9ba287"
+  integrity sha512-aO50/qPC7X2ChjRFniRiscxBLT/K01bALqfcDaf8Ih5OqQ1N4iT/Abx9Ofu3/ms446vHTm46FACIuJUmgUQcDQ==
+  dependencies:
+    chalk "^2.3.0"
+    find-root "^1.0.0"
+    lodash "^4.17.4"
+    semver "^5.4.1"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -4510,7 +4520,7 @@ find-pkg@^0.1.0:
   dependencies:
     find-file-up "^0.1.2"
 
-find-root@^1.1.0:
+find-root@^1.0.0, find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
   integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
@@ -10580,7 +10590,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==


### PR DESCRIPTION
A way to test cw-components locally.

Instruction will be available on cw-components repo. Here is the PR: https://github.com/ClimateWatch-Vizzuality/climate-watch-components/pull/116