### PR TITLE
Move compare button to header in Climate Goals section

### DIFF
--- a/app/javascript/app/constants/links.js
+++ b/app/javascript/app/constants/links.js
@@ -1,2 +1,3 @@
 export const GLOBAL_CW_PLATFORM = 'https://www.climatewatchdata.org';
 export const WRI_WEBSITE = 'https://www.wri.org/';
+export const COMPARE_NDC_LINK = 'https://www.climatewatchdata.org/ndcs/compare/';

--- a/app/javascript/app/layouts/sections/sections-component.jsx
+++ b/app/javascript/app/layouts/sections/sections-component.jsx
@@ -2,11 +2,18 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Sticky from 'react-stickynode';
 import universal from 'react-universal-component';
-import { Loading } from 'cw-components';
+import { Loading, Button, Icon } from 'cw-components';
 import Nav from 'components/nav';
+import button from 'styles/themes/button';
+import iconStyles from 'styles/themes/icon';
+import openInNewIcon from 'assets/icons/open_in_new';
+import cx from 'classnames';
+import { COMPARE_NDC_LINK } from 'constants/links';
 
 import navStyles from 'components/nav/nav-styles';
 import styles from './sections-styles.scss';
+
+const { COUNTRY_ISO } = process.env;
 
 const universalOptions = {
   loading: <Loading height={500} />,
@@ -29,6 +36,11 @@ class Section extends PureComponent {
     }
   }
 
+  handleCompareBtnClick = () => {
+    const { section } = this.props;
+    window.open(`${COMPARE_NDC_LINK}${section.slug}?locations=${COUNTRY_ISO}`, '_blank');
+  };
+
   render() {
     const { route, section, provinceInfo, t } = this.props;
     const title = t(`pages.${route.slug}.title`)
@@ -36,13 +48,35 @@ class Section extends PureComponent {
     const description = t(`pages.${route.slug}.description`);
     const subsectionTitle = t(`pages.${route.slug}.${section.slug}.title`);
     const subsectionDescription = t(`pages.${route.slug}.${section.slug}.description`);
+    const isClimateGoalsSection = title === t('pages.climate-goals.title');
 
     return (
       <div className={styles.page}>
         <div className={styles.section} style={{ backgroundImage: `url('${backgrounds[route.link]}')` }}>
           <div className={styles.row}>
             <h2 className={styles.sectionTitle}>{title}</h2>
-            <p className={styles.sectionDescription} dangerouslySetInnerHTML={{ __html: description }} />
+            <div className={styles.descContainer}>
+              <p className={styles.sectionDescription} dangerouslySetInnerHTML={{ __html: description }} />
+              {isClimateGoalsSection && (
+                <div className={styles.compareButton}>
+                  <Button
+                    onClick={this.handleCompareBtnClick}
+                    theme={{ button: cx(button.primary, styles.button) }}
+                  >
+                    <span
+                      className={styles.buttonText}
+                      dangerouslySetInnerHTML={{
+                        __html: t('pages.climate-goals.overview.button-title')
+                      }}
+                    />
+                    <Icon
+                      theme={{ icon: iconStyles.openInNewIcon }}
+                      icon={openInNewIcon}
+                    />
+                  </Button>
+                </div>
+              )}
+            </div>
           </div>
           <Sticky ref={el => { this.stickyRef = el }} onStateChange={this.handleStickyChange} top="#header" activeClass={styles.stickyWrapper} innerZ={3}>
             <div className={styles.row}>

--- a/app/javascript/app/layouts/sections/sections-styles.scss
+++ b/app/javascript/app/layouts/sections/sections-styles.scss
@@ -55,8 +55,32 @@
   padding-bottom: 10px;
 }
 
+.descContainer {
+  padding-bottom: $gutter-padding * 2;
+
+  @media #{$tablet-landscape} {
+    display: flex;
+    align-items: center;
+  }
+}
+
 .sectionDescription {
   color: $white;
   line-height: 1.6;
-  padding-bottom: $gutter-padding * 2;
+  padding-right: 20px;
+
+  @media #{$tablet-landscape} {
+    flex: 60%;
+  }
+}
+
+.compareButton {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 20px;
+
+  @media #{$tablet-landscape} {
+    justify-content: flex-end;
+    margin-top: 0;
+  }
 }

--- a/app/javascript/app/pages/climate-goals/overview/overview-component.jsx
+++ b/app/javascript/app/pages/climate-goals/overview/overview-component.jsx
@@ -1,23 +1,14 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Card, Button, Icon } from 'cw-components';
+import { Card } from 'cw-components';
 import cx from 'classnames';
-import openInNewIcon from 'assets/icons/open_in_new';
 import NdcContentOverviewProvider from 'providers/ndc-content-overview-provider';
 import SectionTitle from 'components/section-title';
-import button from 'styles/themes/button';
-import iconStyles from 'styles/themes/icon';
 import get from 'lodash/get';
 import Timeline from './timeline';
 import styles from './overview-styles.scss';
 
-const COMPARE_INDONESIA_NDC_LINK = 'https://www.climatewatchdata.org/ndcs/compare/overview?locations=IDN';
-
 class Overview extends PureComponent {
-  handleBtnClick = () => {
-    window.open(COMPARE_INDONESIA_NDC_LINK, '_blank');
-  };
-
   renderCards = () => {
     const { sectors, values, t, nonGhgMitigationCards } = this.props;
     const renderSubtitle = text => <h4 className={styles.subTitle}>{text}</h4>;
@@ -153,21 +144,6 @@ class Overview extends PureComponent {
             <SectionTitle
               title={t('pages.climate-goals.overview.overview-title')}
             />
-            <Button
-              onClick={this.handleBtnClick}
-              theme={{ button: cx(button.primary, styles.button) }}
-            >
-              <span
-                className={styles.buttonText}
-                dangerouslySetInnerHTML={{
-                  __html: t('pages.climate-goals.overview.button-title')
-                }}
-              />
-              <Icon
-                theme={{ icon: iconStyles.openInNewIcon }}
-                icon={openInNewIcon}
-              />
-            </Button>
           </div>
           <div className={styles.description}>
             {description}


### PR DESCRIPTION
Remove the compare button from the Overview specific section header and move it to the main header common for all the climate goals tabs.

![image](https://user-images.githubusercontent.com/6136899/52733615-13421b00-2fbb-11e9-81bc-09c9ace6332a.png)
