### PR TITLE
Feature/changes in ghg emissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,16 @@ These will create the development database and then run the database migration t
 You'll need to run both the rails server and the webpack server, which will be used internally by rails. Run, separately:
 
 ```
-bundle exec rails s
+yarn rails:server
 ```
 
 and
+
+```
+yarn js:server
+```
+
+or run both:
 
 ```
 yarn start

--- a/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-component.jsx
+++ b/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-component.jsx
@@ -52,7 +52,6 @@ class Historical extends PureComponent {
     if (absoluteMetric && field === 'sector') {
       options = options.filter(v => v.code !== SECTOR_TOTAL);
     }
-
     const noAllSelected = NON_ALL_SELECTED_KEYS.includes(field);
 
     if (noAllSelected) return options;

--- a/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-component.jsx
+++ b/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-component.jsx
@@ -16,7 +16,7 @@ import lineIcon from 'assets/icons/line_chart.svg';
 import areaIcon from 'assets/icons/area_chart.svg';
 import styles from './historical-emissions-styles.scss';
 
-const NON_ALL_SELECTED_KEYS = [ 'breakBy', 'chartType', 'provinces' ];
+const NON_ALL_SELECTED_KEYS = [ 'breakBy', 'chartType', 'region' ];
 
 class Historical extends PureComponent {
   handleFilterChange = (field, selected) => {
@@ -150,7 +150,7 @@ class Historical extends PureComponent {
         {this.renderSwitch()}
         <div className={styles.dropdowns}>
           {this.renderDropdown('breakBy')}
-          {this.renderDropdown('provinces', true)}
+          {this.renderDropdown('region', true)}
           {this.renderDropdown('sector', true)}
           {this.renderDropdown('gas', true)}
           {this.renderDropdown('chartType', false, icons)}

--- a/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-data-selectors.js
+++ b/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-data-selectors.js
@@ -32,7 +32,7 @@ import {
 } from './historical-emissions-filter-selectors';
 
 const { COUNTRY_ISO } = process.env;
-const FRONTEND_FILTERED_FIELDS = [ 'provinces', 'sector' ];
+const FRONTEND_FILTERED_FIELDS = [ 'region', 'sector' ];
 
 const getUnit = createSelector([ getMetadata, getMetricSelected ], (
   meta,
@@ -107,7 +107,7 @@ const getYColumnOptions = createSelector(
 );
 
 const getDFilterValue = (d, modelSelected) =>
-  modelSelected === 'provinces' ? d.iso_code3 : d[modelSelected];
+  modelSelected === 'region' ? d.iso_code3 : d[modelSelected];
 
 const isOptionSelected = (selectedOptions, valueOrCode) =>
   castArray(selectedOptions).some(
@@ -217,7 +217,7 @@ const parseTargetEmissionsData = createSelector(
     if (isEmpty(targetEmissionsData)) return null;
     if (metricSelected !== METRIC_OPTIONS.ABSOLUTE_VALUE) return null;
     if (!selectedOptions) return null;
-    if (!isOptionSelected(selectedOptions.provinces, COUNTRY_ISO)) return null;
+    if (!isOptionSelected(selectedOptions.region, COUNTRY_ISO)) return null;
     if (
       isOptionSelected(selectedOptions.chartType, 'line') &&
         modelSelected === 'sector'

--- a/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-filter-selectors.js
+++ b/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-filter-selectors.js
@@ -49,7 +49,10 @@ export const getNationalOption = createSelector([ getTranslate, getMetadata ], (
     return {
       ...findOption(meta.location, COUNTRY_ISO, 'iso_code3'),
       code: COUNTRY_ISO,
-      label: t('pages.national-context.historical-emissions.provinces.national')
+      label: t(
+        'pages.national-context.historical-emissions.provinces.national'
+      ),
+      override: true
     };
   });
 
@@ -92,7 +95,7 @@ const getFieldOptions = field =>
             }))
             .filter(o => o.code !== COUNTRY_ISO);
 
-          options = [ top10EmmmitersOption, nationalOption, ...options ];
+          options = [ nationalOption, top10EmmmitersOption, ...options ];
           break;
         }
         default: {
@@ -171,19 +174,14 @@ const getDefaults = createSelector(
   [
     getFilterOptions,
     getBreakByOptions,
-    getTop10EmittersOptionExpanded,
+    getNationalOption,
     getAllSelectedOption
   ],
-  (
-    options,
-    breakByOptions,
-    top10EmmmitersOptionExpanded,
-    allSelectedOption
-  ) => ({
+  (options, breakByOptions, nationalOption, allSelectedOption) => ({
     source: findOption(options.source, 'SIGN SMART'),
     chartType: findOption(CHART_TYPE_OPTIONS, 'line'),
     breakBy: findOption(breakByOptions, 'provinces-absolute'),
-    provinces: top10EmmmitersOptionExpanded,
+    provinces: nationalOption,
     sector: allSelectedOption,
     gas: allSelectedOption
   })

--- a/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-filter-selectors.js
+++ b/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-filter-selectors.js
@@ -49,9 +49,7 @@ export const getNationalOption = createSelector([ getTranslate, getMetadata ], (
     return {
       ...findOption(meta.location, COUNTRY_ISO, 'iso_code3'),
       code: COUNTRY_ISO,
-      label: t(
-        'pages.national-context.historical-emissions.provinces.national'
-      ),
+      label: t('pages.national-context.historical-emissions.region.national'),
       override: true
     };
   });
@@ -163,7 +161,7 @@ export const getTop10EmittersOptionExpanded = createSelector(
 export const getFilterOptions = createStructuredSelector({
   source: getFieldOptions('dataSource'),
   breakBy: getBreakByOptions,
-  provinces: getFieldOptions('location'),
+  region: getFieldOptions('location'),
   sector: getFieldOptions('sector'),
   gas: getFieldOptions('gas'),
   chartType: () => CHART_TYPE_OPTIONS
@@ -180,8 +178,8 @@ const getDefaults = createSelector(
   (options, breakByOptions, nationalOption, allSelectedOption) => ({
     source: findOption(options.source, 'SIGN SMART'),
     chartType: findOption(CHART_TYPE_OPTIONS, 'line'),
-    breakBy: findOption(breakByOptions, 'provinces-absolute'),
-    provinces: nationalOption,
+    breakBy: findOption(breakByOptions, 'region-absolute'),
+    region: nationalOption,
     sector: allSelectedOption,
     gas: allSelectedOption
   })
@@ -219,7 +217,7 @@ export const getSelectedOptions = createStructuredSelector({
   source: getFieldSelected('source'),
   chartType: getFieldSelected('chartType'),
   breakBy: getFieldSelected('breakBy'),
-  provinces: getFieldSelected('provinces'),
+  region: getFieldSelected('region'),
   sector: filterSectorSelectedByMetrics,
   gas: getFieldSelected('gas')
 });

--- a/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-get-selectors.js
+++ b/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-get-selectors.js
@@ -11,5 +11,5 @@ export const getQuery = ({ location }) => location && location.query || null;
 
 export const getTop10EmittersOptionLabel = createSelector(
   getTranslate,
-  t => t('pages.national-context.historical-emissions.provinces.top-10')
+  t => t('pages.national-context.historical-emissions.region.top-10')
 );

--- a/config/locales/en/app/pages/national_context.yml
+++ b/config/locales/en/app/pages/national_context.yml
@@ -24,14 +24,14 @@ en:
           description: ''
           labels:
             break-by: Break by
-            provinces: Provinces
+            provinces: Regions
             sector: Sector
             gas: Gas
             chart-type: Chart Type
           break-by:
-            provinces-absolute: Province - Absolute
-            provinces-per_gdp: Province - Per GDP
-            provinces-per_capita: Province - Per Capita
+            provinces-absolute: Region - Absolute
+            provinces-per_gdp: Region - Per GDP
+            provinces-per_capita: Region - Per Capita
             sector-absolute: Sector - Absolute
             sector-per_gdp: Sector - Per GDP
             sector-per_capita: Sector - Per Capita
@@ -40,6 +40,7 @@ en:
             gas-per_capita: Gas - Per Capita
           provinces:
             top-10: Top 10 Emitters
+            national: National
           target-labels:
             bau: BAU
             quantified: Quantified

--- a/config/locales/en/app/pages/national_context.yml
+++ b/config/locales/en/app/pages/national_context.yml
@@ -24,17 +24,17 @@ en:
           description: ''
           labels:
             break-by: Break by
-            provinces: Regions
+            region: Region
             sector: Sector
             gas: Gas
             chart-type: Chart Type
           break-by:
-            provinces-absolute: Region - Absolute
-            provinces-per_gdp: Region - Per GDP
-            provinces-per_capita: Region - Per Capita
+            region-absolute: Region - Absolute
+            region-per_gdp: Region - Per GDP
+            region-per_capita: Region - Per Capita
             sector-absolute: Sector
             gas-absolute: Gas
-          provinces:
+          region:
             top-10: Top 10 Emitters
             national: National
           target-labels:

--- a/config/locales/en/app/pages/national_context.yml
+++ b/config/locales/en/app/pages/national_context.yml
@@ -32,12 +32,8 @@ en:
             provinces-absolute: Region - Absolute
             provinces-per_gdp: Region - Per GDP
             provinces-per_capita: Region - Per Capita
-            sector-absolute: Sector - Absolute
-            sector-per_gdp: Sector - Per GDP
-            sector-per_capita: Sector - Per Capita
-            gas-absolute: Gas - Absolute
-            gas-per_gdp: Gas - Per GDP
-            gas-per_capita: Gas - Per Capita
+            sector-absolute: Sector
+            gas-absolute: Gas
           provinces:
             top-10: Top 10 Emitters
             national: National

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "cw-indonesia",
   "version": "1.0.0",
   "scripts": {
-    "start": "./bin/webpack-dev-server",
+    "start": "yarn js:server & yarn rails:server",
+    "js:server": "yarn install && ./bin/webpack-dev-server",
+    "rails:server": "bundle exec rails s",
     "reinstall": "rm -rf node_modules && yarn install",
     "precommit": "lint-staged",
     "lint": "eslint --ext js --ext jsx .",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "compression-webpack-plugin": "1.0.0",
     "core-js": "2.5.3",
     "css-loader": "0.28.7",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.38.0",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.39.0",
     "d3-scale": "^2.1.2",
     "directory-named-webpack-plugin": "4.0.0",
     "dotenv": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,6 +91,20 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@d3fc/d3fc-discontinuous-scale@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@d3fc/d3fc-discontinuous-scale/-/d3fc-discontinuous-scale-3.0.7.tgz#4b56876d0a9dd6ad7bfdd07849a0b4e9fa255074"
+  integrity sha512-2/M+WqzN9wkmS5ElmNZKeBmPlcsMY4lOw+AEFxcFZiEc2bGv/7GusiU/9XYsvtkyfEbl9cihi+o34y09Hbij3Q==
+  dependencies:
+    "@d3fc/d3fc-rebind" "^5.0.6"
+    d3-scale "^1.0.0"
+    d3-time "^1.0.0"
+
+"@d3fc/d3fc-rebind@^5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@d3fc/d3fc-rebind/-/d3fc-rebind-5.0.6.tgz#2c3abacb24827f98592cb2eae9913a76cb2391c8"
+  integrity sha512-ZT6wRZ7HkDav71prw6BUD3ER7Y40xuAhqGbdVeXaEy6OFzOipE8NgrVWYh7HHb30GFgO+ygpnAeLtuxQmugIwQ==
+
 "@latticejs/recharts-sunburst@^1.0.1-beta.0":
   version "1.0.1-beta.0"
   resolved "https://registry.yarnpkg.com/@latticejs/recharts-sunburst/-/recharts-sunburst-1.0.1-beta.0.tgz#560a7152bc15cea279e7347dac3c778553b3adbd"
@@ -3104,10 +3118,11 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.38.0":
-  version "1.38.0"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/c7adcf4cfb1e7fc7d5e5023f8b1b09b468c15ce2"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.39.0":
+  version "1.39.0"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/6749d8528afb334e973c857660034f6778739278"
   dependencies:
+    "@d3fc/d3fc-discontinuous-scale" "^3.0.7"
     "@latticejs/recharts-sunburst" "^1.0.1-beta.0"
     d3-format "1.3.0"
     d3-hierarchy "^1.1.8"
@@ -3222,6 +3237,19 @@ d3-scale@1.0.6:
     d3-time "1"
     d3-time-format "2"
 
+d3-scale@^1.0.0:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.7.tgz#fa90324b3ea8a776422bd0472afab0b252a0945d"
+  integrity sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-color "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
 d3-scale@^2.1.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.2.2.tgz#4e880e0b2745acaaddd3ede26a9e908a9e17b81f"
@@ -3274,7 +3302,7 @@ d3-time-format@2:
   dependencies:
     d3-time "1"
 
-d3-time@1:
+d3-time@1, d3-time@^1.0.0:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.11.tgz#1d831a3e25cd189eb256c17770a666368762bbce"
   integrity sha512-Z3wpvhPLW4vEScGeIMUckDW7+3hWKOQfAWg/U7PlWBnQmeKQ00gCUsTtWSYulrKNA7ta8hJ+xXc6MHrMuITwEw==


### PR DESCRIPTION
A few things here:
- updating cw-components to make more room for targets (https://www.pivotaltracker.com/story/show/163790120)
- changes in national GHG Emissions to be more similar to the one on flagship (https://www.pivotaltracker.com/story/show/163790215)
  - Break by: removed gas and sector per GDP and capita
  - Region: renamed to `Region`, the default selection is `National` which are the values for `Indonesia`
  - `National` can be chosen only exclusively. I could mix `National` with other Provinces for some selections but let's see what they say
  - there was no need, I think, to disable chart option in any case
- showing National total targets only when National option is selected or Break by sectors and chart type is `area`. Not exactly done how story suggests but I think how it's done make sense (https://www.pivotaltracker.com/story/show/163790254)