### PR TITLE
Overview Timeline - open links in a new tab

### DIFF
--- a/app/javascript/app/pages/climate-goals/overview/timeline/timeline-component.jsx
+++ b/app/javascript/app/pages/climate-goals/overview/timeline/timeline-component.jsx
@@ -32,7 +32,9 @@ const table = documents => (
               <p>{document.year}</p>
             </TabletPortraitOnly>
             {document.label && <ReactMarkdown source={document.label} />}
-            <a href={document.link}>Data source</a>
+            <a href={document.link} rel="noopener noreferrer" target="_blank">
+              Data source
+            </a>
           </td>
         </tr>
       ))}


### PR DESCRIPTION
In this PR I clicked around the site and checked if links are opening in new tabs.
Added opening data sources in new tab for Climate Goals - Overview Timeline.

![image](https://user-images.githubusercontent.com/6136899/52855818-6f6f8100-311a-11e9-866c-277fbfaf27b1.png)
