### PR TITLE
Fix css ordering on develop

### DIFF
--- a/app/javascript/app/app.jsx
+++ b/app/javascript/app/app.jsx
@@ -1,5 +1,6 @@
 import 'babel-polyfill';
 import 'whatwg-fetch';
+import 'cw-components/dist/main';
 
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -7,16 +8,6 @@ import { Provider } from 'react-redux';
 
 import store from 'app/store';
 import Root from './layouts/root';
-
-// using try catch to get warning if module not found
-// module will not be found if cw-components linked locally using yarn link
-// but we don't have to import in this case
-try {
-  // eslint-disable-next-line global-require
-  require('cw-components/dist/main');
-} catch (err) {
-  console.warn('cw-components/dist/main not found');
-}
 
 const App = ({ data }) => (
   <Provider store={store(data)}>

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -12,6 +12,7 @@ const { settings, output } = require('./configuration.js');
 
 module.exports = merge(sharedConfig, {
   resolve: {
+    symlinks: false,
     alias: {
       react: path.resolve('./node_modules/react'),
       'react-dom': path.resolve('./node_modules/react-dom')


### PR DESCRIPTION
Require cw-components instead of es6's import was messing up css ordering on develop. Cw-components styles were overriding the project ones:
![image](https://user-images.githubusercontent.com/6136899/52859303-3f2ce000-3124-11e9-84f3-53318a75a46f.png)
I know it was done to facilitate local testing with `yarn link` to cw-components but we can always comment out the import when linking.
