### PR TITLE
Capitalize unit to display in a tooltip

### DIFF
--- a/app/javascript/app/pages/national-context/socioeconomic/energy/energy-selectors.js
+++ b/app/javascript/app/pages/national-context/socioeconomic/energy/energy-selectors.js
@@ -22,7 +22,7 @@ const INDICATOR_QUERY_NAME = 'energyInd';
 const CATEGORIES_QUERY_NAME = 'categories';
 
 export const AXES_CONFIG = (yName, yUnit) => ({
-  xBottom: { name: 'Year', unit: 'date', format: 'YYYY' },
+  xBottom: { name: 'Year', unit: 'Date', format: 'YYYY' },
   yLeft: { name: yName, unit: yUnit, format: 'number' }
 });
 


### PR DESCRIPTION
In the National Context -> Socioeconomic indicators -> Energy, fix capitalization of unit:

![screenshot 2019-02-15 at 14 48 07](https://user-images.githubusercontent.com/6136899/52864010-24149d00-3131-11e9-978f-79b63c4393dc.png)
