### PR TITLE
Minimize warnings in the browser's console

### DIFF
--- a/app/javascript/app/components/regions-select/regions-select-component.jsx
+++ b/app/javascript/app/components/regions-select/regions-select-component.jsx
@@ -40,7 +40,7 @@ RegionsSelect.propTypes = {
   className: PropTypes.string,
   handleClickOutside: PropTypes.func,
   activeProvince: PropTypes.string,
-  parentRef: PropTypes.node
+  parentRef: PropTypes.instanceOf(Element)
 };
 
 RegionsSelect.defaultProps = {

--- a/app/javascript/app/components/results-list/results-list-component.jsx
+++ b/app/javascript/app/components/results-list/results-list-component.jsx
@@ -108,7 +108,7 @@ ResultsList.propTypes = {
   handleMouseItemLeave: PropTypes.func,
   handleClickOutside: PropTypes.func,
   activeProvince: PropTypes.string,
-  parentRef: PropTypes.node
+  parentRef: PropTypes.instanceOf(Element)
 };
 
 ResultsList.defaultProps = {

--- a/app/javascript/app/pages/national-context/socioeconomic/economy/economy-component.jsx
+++ b/app/javascript/app/pages/national-context/socioeconomic/economy/economy-component.jsx
@@ -24,7 +24,8 @@ class Economy extends PureComponent {
       provincesOptions,
       selectedOptions,
       sources,
-      downloadURI
+      downloadURI,
+      loading
     } = this.props;
 
     const nationalIndLabel = t(
@@ -46,16 +47,24 @@ class Economy extends PureComponent {
           <div className="first-column">
             <div className={styles.toolbox}>
               <div className={styles.dropdown}>
-                <Dropdown
-                  key={nationalIndLabel}
-                  label={provinceIndLabel}
-                  options={nationalOptions}
-                  onValueChange={selected =>
-                    this.handleFilterChange('gdpNationalIndicator', selected)}
-                  value={selectedOptions.gdpNationalIndicator}
-                  theme={{ select: dropdownStyles.select }}
-                  hideResetButton
-                />
+                {
+                  nationalOptions &&
+                    (
+                      <Dropdown
+                        key={nationalIndLabel}
+                        label={provinceIndLabel}
+                        options={nationalOptions}
+                        onValueChange={selected =>
+                          this.handleFilterChange(
+                            'gdpNationalIndicator',
+                            selected
+                          )}
+                        value={selectedOptions.gdpNationalIndicator}
+                        theme={{ select: dropdownStyles.select }}
+                        hideResetButton
+                      />
+                    )
+                }
               </div>
               <InfoDownloadToolbox
                 className={{ buttonWrapper: styles.buttonWrapper }}
@@ -81,6 +90,7 @@ class Economy extends PureComponent {
                     data={nationalChartData.data}
                     domain={nationalChartData.domain}
                     height={300}
+                    loading={loading}
                     customMessage={t('common.chart-no-data')}
                   />
                 )
@@ -89,16 +99,21 @@ class Economy extends PureComponent {
           <div className="second-column">
             <div className={styles.toolbox}>
               <div className={styles.dropdown}>
-                <Dropdown
-                  key={provinceIndLabel}
-                  label={provinceIndLabel}
-                  options={provincesOptions}
-                  onValueChange={selected =>
-                    this.handleFilterChange('gdpProvince', selected)}
-                  value={selectedOptions.gdpProvince}
-                  theme={{ select: dropdownStyles.select }}
-                  hideResetButton
-                />
+                {
+                  provincesOptions &&
+                    (
+                      <Dropdown
+                        key={provinceIndLabel}
+                        label={provinceIndLabel}
+                        options={provincesOptions}
+                        onValueChange={selected =>
+                          this.handleFilterChange('gdpProvince', selected)}
+                        value={selectedOptions.gdpProvince}
+                        theme={{ select: dropdownStyles.select }}
+                        hideResetButton
+                      />
+                    )
+                }
               </div>
               <InfoDownloadToolbox
                 className={{ buttonWrapper: styles.buttonWrapper }}
@@ -124,6 +139,7 @@ class Economy extends PureComponent {
                     data={provincialChartData.data}
                     domain={provincialChartData.domain}
                     height={300}
+                    loading={loading}
                     customMessage={t('common.chart-no-data')}
                   />
                 )
@@ -144,7 +160,8 @@ Economy.propTypes = {
   provincesOptions: PropTypes.array,
   selectedOptions: PropTypes.object,
   sources: PropTypes.array,
-  downloadURI: PropTypes.string
+  downloadURI: PropTypes.string,
+  loading: PropTypes.bool.isRequired
 };
 
 Economy.defaultProps = {

--- a/app/javascript/app/pages/national-context/socioeconomic/economy/economy-selectors.js
+++ b/app/javascript/app/pages/national-context/socioeconomic/economy/economy-selectors.js
@@ -12,7 +12,8 @@ import {
   getXColumn,
   getTheme,
   getDomain,
-  getAxes
+  getAxes,
+  getChartsLoading
 } from '../population/population-selectors';
 
 const { COUNTRY_ISO } = process.env;
@@ -258,5 +259,6 @@ export const getEconomy = createStructuredSelector({
   provincesOptions: getProvinceIndicatorsForEconomyOptions,
   selectedOptions: getSelectedOptions,
   sources: getSources,
-  downloadURI: getDownloadURI
+  downloadURI: getDownloadURI,
+  loading: getChartsLoading
 });

--- a/app/javascript/app/pages/national-context/socioeconomic/energy/energy-component.jsx
+++ b/app/javascript/app/pages/national-context/socioeconomic/energy/energy-component.jsx
@@ -28,7 +28,8 @@ class Energy extends PureComponent {
       options,
       t,
       sources,
-      downloadURI
+      downloadURI,
+      loading
     } = this.props;
 
     const indicatorLabel = t(
@@ -44,17 +45,22 @@ class Energy extends PureComponent {
         <div className={styles.container}>
           <div className={styles.toolbox}>
             <div className={styles.dropdown}>
-              <Dropdown
-                key={indicatorLabel}
-                label={indicatorLabel}
-                placeholder={`Filter by ${indicatorLabel}`}
-                options={options}
-                onValueChange={selected =>
-                  this.handleFilterChange('energyInd', selected)}
-                value={selectedOptions.energyInd}
-                theme={{ select: dropdownStyles.select }}
-                hideResetButton
-              />
+              {
+                options &&
+                  (
+                    <Dropdown
+                      key={indicatorLabel}
+                      label={indicatorLabel}
+                      placeholder={`Filter by ${indicatorLabel}`}
+                      options={options}
+                      onValueChange={selected =>
+                        this.handleFilterChange('energyInd', selected)}
+                      value={selectedOptions.energyInd}
+                      theme={{ select: dropdownStyles.select }}
+                      hideResetButton
+                    />
+                  )
+              }
             </div>
             <InfoDownloadToolbox
               className={{ buttonWrapper: styles.buttonWrapper }}
@@ -77,6 +83,7 @@ class Energy extends PureComponent {
                   dataOptions={chartData.dataOptions}
                   dataSelected={chartData.dataSelected}
                   height={500}
+                  loading={loading}
                   showUnit
                   onLegendChange={v => this.handleFilterChange('categories', v)}
                 />
@@ -95,7 +102,8 @@ Energy.propTypes = {
   selectedOptions: PropTypes.object,
   options: PropTypes.array,
   sources: PropTypes.array,
-  downloadURI: PropTypes.string
+  downloadURI: PropTypes.string,
+  loading: PropTypes.bool.isRequired
 };
 
 Energy.defaultProps = {

--- a/app/javascript/app/pages/national-context/socioeconomic/energy/energy-selectors.js
+++ b/app/javascript/app/pages/national-context/socioeconomic/energy/energy-selectors.js
@@ -10,7 +10,8 @@ import { getThemeConfig, getTooltipConfig } from 'utils/graphs';
 
 import {
   getIndicatorsData,
-  getQuery
+  getQuery,
+  getChartsLoading
 } from '../population/population-selectors';
 
 const { COUNTRY_ISO } = process.env;
@@ -316,5 +317,6 @@ export const getEnergy = createStructuredSelector({
   selectedOptions: getSelectedOptions,
   query: getQuery,
   sources: getSources,
-  downloadURI: getDownloadURI
+  downloadURI: getDownloadURI,
+  loading: getChartsLoading
 });

--- a/app/javascript/app/pages/national-context/socioeconomic/population/population-component.jsx
+++ b/app/javascript/app/pages/national-context/socioeconomic/population/population-component.jsx
@@ -24,7 +24,8 @@ class Population extends PureComponent {
       popProvincesOptions,
       selectedOptions,
       sources,
-      downloadURI
+      downloadURI,
+      loading
     } = this.props;
 
     const nationalIndLabel = t(
@@ -74,6 +75,7 @@ class Population extends PureComponent {
                     customTooltip={<CustomTooltip />}
                     getCustomYLabelFormat={chartData.config.yLabelFormat}
                     domain={chartData.domain}
+                    loading={loading}
                     dataOptions={chartData.dataOptions}
                     dataSelected={chartData.dataSelected}
                     height={300}
@@ -119,6 +121,7 @@ class Population extends PureComponent {
                     }
                     data={popProvinceChartData.data}
                     domain={popProvinceChartData.domain}
+                    loading={loading}
                     height={300}
                     barSize={30}
                     customMessage={t('common.chart-no-data')}
@@ -135,15 +138,16 @@ class Population extends PureComponent {
 Population.propTypes = {
   t: PropTypes.func.isRequired,
   onFilterChange: PropTypes.func.isRequired,
-  chartData: PropTypes.object.isRequired,
+  chartData: PropTypes.object,
   popProvinceChartData: PropTypes.object.isRequired,
   nationalIndicatorsOptions: PropTypes.array.isRequired,
   popProvincesOptions: PropTypes.array.isRequired,
   selectedOptions: PropTypes.object.isRequired,
   sources: PropTypes.array.isRequired,
-  downloadURI: PropTypes.string.isRequired
+  downloadURI: PropTypes.string.isRequired,
+  loading: PropTypes.bool.isRequired
 };
 
-Population.defaultProps = {};
+Population.defaultProps = { chartData: null };
 
 export default Population;

--- a/app/javascript/app/pages/national-context/socioeconomic/population/population-selectors.js
+++ b/app/javascript/app/pages/national-context/socioeconomic/population/population-selectors.js
@@ -29,6 +29,9 @@ const getCustomYLabelFormat = unit => {
   return formatY[unit];
 };
 
+export const getChartsLoading = ({ indicators }) =>
+  indicators && indicators.loading;
+
 // POPULATION CHARTS
 export const getNationalIndicators = createSelector(
   [ getIndicatorsData ],
@@ -289,5 +292,6 @@ export const getPopulation = createStructuredSelector({
   popProvincesOptions: getProvinceIndicatorsForPopulationOptions,
   selectedOptions: getSelectedOptions,
   sources: getSources,
-  downloadURI: getDownloadURI
+  downloadURI: getDownloadURI,
+  loading: getChartsLoading
 });

--- a/app/javascript/app/pages/regions/regions-ghg-emissions/regions-ghg-emissions-component.jsx
+++ b/app/javascript/app/pages/regions/regions-ghg-emissions/regions-ghg-emissions-component.jsx
@@ -127,7 +127,13 @@ class RegionsGhgEmissions extends PureComponent {
   }
 
   render() {
-    const { emissionParams, selectedYear, provinceISO, t } = this.props;
+    const {
+      emissionParams,
+      selectedYear,
+      provinceISO,
+      t,
+      chartData
+    } = this.props;
 
     const sources = [ 'RADGRK', 'SIGNSa' ];
     const downloadURI = `emissions/download?source=${sources.join(
@@ -154,7 +160,7 @@ class RegionsGhgEmissions extends PureComponent {
                 />
               </div>
               <div className={styles.chartContainer}>
-                {this.renderChart()}
+                {chartData && this.renderChart()}
               </div>
             </div>
             <TabletLandscape>

--- a/app/javascript/app/pages/regions/sectoral-circumstances/bar-chart/bar-chart-component.jsx
+++ b/app/javascript/app/pages/regions/sectoral-circumstances/bar-chart/bar-chart-component.jsx
@@ -33,6 +33,7 @@ class BarChart extends PureComponent {
                 domain={chartData.domain}
                 dataOptions={chartData.dataOptions}
                 dataSelected={chartData.dataSelected}
+                loading={chartData.loading}
                 hideRemoveOptions
                 height={300}
                 barSize={barSize}

--- a/app/javascript/app/pages/regions/sectoral-circumstances/sectoral-circumstances-selectors.js
+++ b/app/javascript/app/pages/regions/sectoral-circumstances/sectoral-circumstances-selectors.js
@@ -13,6 +13,8 @@ const CHART_COLORS = [ '#FC7E4B', '#2EC9DF', '#0845CB' ];
 
 const getAllIndicators = ({ indicators }) => indicators && indicators.data;
 
+const getChartLoading = ({ indicators }) => indicators && indicators.loading;
+
 const getIndicators = indicatorCode =>
   createSelector(getAllIndicators, indicators => {
     if (!indicators) return null;
@@ -151,7 +153,8 @@ const getChartData = (indicatorCode, chartColors) =>
     config: getChartConfig(indicatorCode, chartColors),
     dataOptions: getYColumnOptions(indicatorCode),
     dataSelected: getYColumnOptions(indicatorCode),
-    domain: getDomain
+    domain: getDomain,
+    loading: getChartLoading
   });
 
 const getSources = indicatorCode =>

--- a/app/javascript/app/pages/regions/vulnerability-adaptivity/vulnerability-adaptivity-component.jsx
+++ b/app/javascript/app/pages/regions/vulnerability-adaptivity/vulnerability-adaptivity-component.jsx
@@ -132,7 +132,7 @@ VulnerabilityAdaptivity.propTypes = {
   selectedYear: PropTypes.object,
   vulnerabilityClassIndicator: PropTypes.shape({
     indicatorName: PropTypes.string,
-    value: PropTypes.string
+    value: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ])
   }),
   sources: PropTypes.array,
   downloadURI: PropTypes.string,


### PR DESCRIPTION
The console in the browser was flooded with warnings. I fixed some of these, I hope all of them that were dependent on the platform and not caused by cw-components. The ones happening inside cw-components will be handled in a different PR and in the cw-components repo.