### PR TITLE
Using titles instead of short titles, metadata modal

### DIFF
--- a/app/javascript/app/components/modal-metadata/modal-metadata-selectors.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-selectors.js
@@ -30,7 +30,7 @@ export const getModalTitle = createSelector([ getTitle, getModalData ], (
 
 export const getTabTitles = createSelector(
   getModalData,
-  data => data && data.length > 1 ? data.map(d => d.short_title) : null
+  data => data && data.length > 1 ? data.map(d => d.title) : null
 );
 
 export default { getModalTitle, getModalData, getTabTitles };


### PR DESCRIPTION
Quick one-liner, as they actually want full titles for metadata modal tabs

![image](https://user-images.githubusercontent.com/1286444/53089061-c8b92500-350b-11e9-92d8-c6fc3c0ae769.png)

basecamp: https://basecamp.com/1756858/projects/15229620/todos/380527319#comment_682467876