### PR TITLE
Feature/province module feedback

### DIFF
--- a/app/javascript/app/components/map/map-component.jsx
+++ b/app/javascript/app/components/map/map-component.jsx
@@ -98,12 +98,14 @@ class MapComponent extends Component {
             <ComposableMap projection="robinson" style={style}>
               <ZoomableGroup zoom={z} center={[ x, y ]}>
                 <Geographies
-                  geography={paths}
+                  geographyPaths={paths}
                   disableOptimization={forceUpdate || !cache}
                 >
                   {(geographies, projection) => geographies.map(geography => {
                     if (geography) {
                       let commonProps = {
+                        key:
+                          geography.properties && geography.properties.id,
                         geography,
                         projection,
                         onClick: onGeographyClick,

--- a/app/javascript/app/pages/regions/regions-ghg-emissions/ghg-map/ghg-map-component.jsx
+++ b/app/javascript/app/pages/regions/regions-ghg-emissions/ghg-map/ghg-map-component.jsx
@@ -8,6 +8,7 @@ import styles from './ghg-map-styles.scss';
 
 const MAP_ZOOM_STEP = 2;
 const MAP_ZOOM_DEFAULT = 12;
+const MAP_ZOOM_MIN = 6;
 
 const MapTooltip = ({ properties }) => (
   <div>
@@ -43,7 +44,10 @@ class GHGMap extends PureComponent {
   };
 
   handleZoomOut = () => {
-    this.setState(({ mapZoom }) => ({ mapZoom: mapZoom / MAP_ZOOM_STEP }));
+    this.setState(({ mapZoom }) => {
+      const newMapZoom = mapZoom / MAP_ZOOM_STEP;
+      return { mapZoom: newMapZoom < MAP_ZOOM_MIN ? mapZoom : newMapZoom };
+    });
   };
 
   render() {

--- a/app/javascript/app/pages/regions/regions-ghg-emissions/ghg-map/ghg-map-component.jsx
+++ b/app/javascript/app/pages/regions/regions-ghg-emissions/ghg-map/ghg-map-component.jsx
@@ -24,14 +24,17 @@ class GHGMap extends PureComponent {
   }
 
   handleProvinceClick = e => {
-    const { linkToProvinceGHG } = this.props;
+    const { linkToProvinceGHG, query } = this.props;
     const provinceISO = e.properties && e.properties.code_hasc;
 
     if (!provinceISO) return;
 
+    const metricQuery = query && query.metric && { metric: query.metric };
+
     linkToProvinceGHG({
       section: 'regions-ghg-emissions',
-      region: provinceISO
+      region: provinceISO,
+      query: metricQuery
     });
   };
 

--- a/app/javascript/app/pages/regions/regions-ghg-emissions/regions-ghg-emissions-component.jsx
+++ b/app/javascript/app/pages/regions/regions-ghg-emissions/regions-ghg-emissions-component.jsx
@@ -127,7 +127,7 @@ class RegionsGhgEmissions extends PureComponent {
   }
 
   render() {
-    const { emissionParams, selectedYear, provinceISO, t } = this.props;
+    const { emissionParams, selectedYear, provinceISO, t, query } = this.props;
 
     const sources = [ 'RADGRK', 'SIGNSa' ];
     const downloadURI = `emissions/download?source=${sources.join(
@@ -158,7 +158,7 @@ class RegionsGhgEmissions extends PureComponent {
               </div>
             </div>
             <TabletLandscape>
-              <GHGMap selectedYear={selectedYear} />
+              <GHGMap selectedYear={selectedYear} query={query} />
             </TabletLandscape>
           </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-motion": "^0.5.2",
     "react-redux": "5.0.7",
     "react-responsive": "^5.0.0",
-    "react-simple-maps": "^0.12.1",
+    "react-simple-maps": "0.8.3",
     "react-stickynode": "^2.0.1",
     "react-tooltip": "3.6.1",
     "react-universal-component": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6271,10 +6271,18 @@ js-yaml@3.9.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.12.0, js-yaml@^3.4.3, js-yaml@^3.9.0, js-yaml@^3.9.1:
+js-yaml@^3.12.0, js-yaml@^3.4.3, js-yaml@^3.9.0:
   version "3.12.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
   integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.9.1:
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.2.tgz#ef1d067c5a9d9cb65bd72f285b5d8105c77f14fc"
+  integrity sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -9625,6 +9633,15 @@ react-selectize@3.0.1:
     prelude-extension "^0.1.0"
     prelude-ls "^1.1.1"
     tether "^1.1.1"
+
+react-simple-maps@0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/react-simple-maps/-/react-simple-maps-0.8.3.tgz#a640f0200dbebb9879affe5e5975bdb18af72c03"
+  integrity sha512-Uja5l+2YJ/QWi+Ih6zoaMGeLaC5YPqZwYNWmX6ozAlXxlROIEU2jhi40Ze0dEourYdx6KqBWy6YvM8tl7Zg6uQ==
+  dependencies:
+    d3-geo "1.6.3"
+    d3-geo-projection "1.2.2"
+    topojson-client "2.1.0"
 
 react-simple-maps@^0.12.1:
   version "0.12.1"


### PR DESCRIPTION
This PR tweaks a few display issues in Province Module/GHG Emission
[BASECAMP](https://basecamp.com/1756858/projects/15229620/todos/378225736) | [PIVOTAL](https://www.pivotaltracker.com/story/show/164241775)

- preserve selected metric when clicking on a new province on the map,
- add fixed state of minimum zoom on the map,
- now we can navigate with the map-component by clicking on empty space and dragging the map (check [Rizkys' comment](https://basecamp.com/1756858/projects/15229620/todos/378225736#comment_683889864))
To make this work, sadly I had to downgrade version of `react-simple-maps` to 0.8.3 (cw flagship version), because with the higher version it didn't work. I'm not sure where the problem is, but I think it's the fastest solution for now.

![ju96x-mg8vg](https://user-images.githubusercontent.com/15097138/53496805-b35b7200-3a9a-11e9-88f3-f5af9fa99c22.gif)
