### PR TITLE
Feature/chart info buttons on right side

### DIFF
--- a/app/javascript/app/pages/national-context/climate-funding/climate-funding-styles.scss
+++ b/app/javascript/app/pages/national-context/climate-funding/climate-funding-styles.scss
@@ -8,7 +8,8 @@
 }
 
 .actions {
-  @include columns($columns: (4,2));
+  display: flex;
+  justify-content: space-between;
 }
 
 .input {

--- a/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-component.jsx
+++ b/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-component.jsx
@@ -148,12 +148,14 @@ class Historical extends PureComponent {
           )}
         />
         {this.renderSwitch()}
-        <div className={styles.dropdowns}>
-          {this.renderDropdown('breakBy')}
-          {this.renderDropdown('region', true)}
-          {this.renderDropdown('sector', true)}
-          {this.renderDropdown('gas', true)}
-          {this.renderDropdown('chartType', false, icons)}
+        <div className={styles.filtersGroup}>
+          <div className={styles.filters}>
+            {this.renderDropdown('breakBy')}
+            {this.renderDropdown('region', true)}
+            {this.renderDropdown('sector', true)}
+            {this.renderDropdown('gas', true)}
+            {this.renderDropdown('chartType', false, icons)}
+          </div>
           <InfoDownloadToolbox
             className={{ buttonWrapper: styles.buttonWrapper }}
             slugs={sources}

--- a/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-styles.scss
+++ b/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-styles.scss
@@ -7,14 +7,15 @@
   margin-top: $gutter-padding;
 }
 
-.dropdowns {
+.filtersGroup {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin: 25px;
+}
+
+.filters {
   @include columns($columns: 12);
-
-  @media #{$tablet-landscape} {
-    padding-left: $gutter-padding / 2;
-
-    @include columns($columns: (3,2,2,2,1.5,2));
-  }
 }
 
 .buttonWrapper {
@@ -24,10 +25,6 @@
 
 .switch {
   @include columns($columns: 12);
-
-  @media #{$tablet-landscape} {
-    @include columns($columns: 4);
-  }
 
   .switchWrapper {
     margin-left: $gutter-padding / 2;
@@ -58,4 +55,18 @@
 
 .projectedLegend {
   margin-left: 0;
+}
+
+@media #{$tablet-landscape} {
+  .filters {
+    @include columns($columns: (3,2,2,2,1.5,2));
+  }
+
+  .switch {
+    @include columns($columns: 4);
+  }
+
+  .filtersGroup {
+    flex-direction: row;
+  }
 }

--- a/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-component.jsx
+++ b/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-component.jsx
@@ -152,20 +152,20 @@ class SectoralActivity extends Component {
           <div className={styles.mapContainer}>
             {
               map && (
-              <React.Fragment>
-                <Map
-                  zoom={5}
-                  paths={map.paths}
-                  forceUpdate
-                  center={MAP_CENTER}
-                  className={styles.map}
-                  tooltip={MapTooltip}
-                />
-                <div className={styles.legend}>
-                  <DotLegend legend={map.legend} />
-                </div>
-                {yearsSelectable && this.renderTimeline()}
-              </React.Fragment>
+                  <React.Fragment>
+                    <Map
+                      zoom={5}
+                      paths={map.paths}
+                      forceUpdate
+                      center={MAP_CENTER}
+                      className={styles.map}
+                      tooltip={MapTooltip}
+                    />
+                    <div className={styles.legend}>
+                      <DotLegend legend={map.legend} />
+                    </div>
+                    {yearsSelectable && this.renderTimeline()}
+                  </React.Fragment>
                 )
             }
           </div>

--- a/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-component.jsx
+++ b/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-component.jsx
@@ -133,10 +133,12 @@ class SectoralActivity extends Component {
               'pages.national-context.sectoral-activity.description'
             )}
           />
-          <div className={styles.dropdowns}>
-            {this.renderDropdown('indicator')}
-            {this.renderDropdown('activity')}
-            {yearsSelectable && this.renderDropdown('year')}
+          <div className={styles.filtersGroup}>
+            <div className={styles.filters}>
+              {this.renderDropdown('indicator')}
+              {this.renderDropdown('activity')}
+              {yearsSelectable && this.renderDropdown('year')}
+            </div>
             <InfoDownloadToolbox
               className={{ buttonWrapper: styles.buttonWrapper }}
               slugs={sources}

--- a/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-styles.scss
+++ b/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-styles.scss
@@ -15,20 +15,17 @@
   @include row();
 }
 
-.dropdowns {
-  @include columns($columns: 12);
-
+.filtersGroup {
+  display: flex;
+  flex-direction: column;
   margin-bottom: 25px;
+}
 
-  @media #{$tablet-landscape} {
-    padding-left: $gutter-padding / 2;
-
-    @include columns($columns: (3,3,2));
-  }
+.filters {
+  @include xy-gutters($gutter-position: ('bottom'));
 }
 
 .buttonWrapper {
-  align-self: flex-end;
   max-width: 100px;
 }
 
@@ -46,11 +43,6 @@
 .legend {
   margin-bottom: 30px;
   min-height: 150px;
-
-  @media #{$tablet-landscape} {
-    margin-top: -100px;
-    margin-bottom: 0;
-  }
 }
 
 :global {
@@ -67,3 +59,22 @@
   }
 }
 
+@media #{$tablet-landscape} {
+  .filtersGroup {
+    flex-direction: row;
+  }
+
+  .filters {
+    @include columns($columns: (3,3,2));
+    margin-bottom: 0;
+  }
+
+  .legend {
+    margin-top: -100px;
+    margin-bottom: 0;
+  }
+
+  .buttonWrapper {
+    align-self: flex-end;
+  }
+}

--- a/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-styles.scss
+++ b/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-styles.scss
@@ -66,6 +66,7 @@
 
   .filters {
     @include columns($columns: (3,3,2));
+
     margin-bottom: 0;
   }
 

--- a/app/javascript/app/pages/national-context/socioeconomic/energy/energy-styles.scss
+++ b/app/javascript/app/pages/national-context/socioeconomic/energy/energy-styles.scss
@@ -19,6 +19,7 @@ $dropdown-min-width: 265px;
 
 .toolbox {
   display: flex;
+  justify-content: space-between;
   margin-bottom: 20px;
 }
 

--- a/app/javascript/app/pages/regions/climate-sectoral-plan/climate-plans/climate-plans-styles.scss
+++ b/app/javascript/app/pages/regions/climate-sectoral-plan/climate-plans/climate-plans-styles.scss
@@ -22,5 +22,6 @@ $borderRadius: 4px;
 }
 
 .actions {
-  @include columns($columns: (4,3));
+  display: flex;
+  justify-content: space-between;
 }

--- a/app/javascript/app/pages/regions/vulnerability-adaptivity/vulnerability-adaptivity-styles.scss
+++ b/app/javascript/app/pages/regions/vulnerability-adaptivity/vulnerability-adaptivity-styles.scss
@@ -20,6 +20,7 @@
 
 .toolbox {
   display: flex;
+  justify-content: space-between;
   margin-top: 25px;
   margin-bottom: 25px;
 


### PR DESCRIPTION
This PR moves chart's info buttons to the right side, like on the flagship. (this is already done for [india here](https://github.com/ClimateWatch-Vizzuality/india-platform/pull/47))
[PIVOTAL ](https://www.pivotaltracker.com/story/show/164241685) | [BASECAMP](https://basecamp.com/1756858/projects/15229620/todos/380995498)

Changes are made for:

 **National context:**
- Socioeconomic Indicators / Energy
- Historical emissions
- Emission-producing Activity
- Climate finance

**Province module**
- GHG emissions and targets
- Vulnerability and adaptivity
- Climate Sectoral Plan