### PR TITLE
Update Sumatera Selatan code_hasc

### DIFF
--- a/app/javascript/app/utils/maps/indonesia.json
+++ b/app/javascript/app/utils/maps/indonesia.json
@@ -1737,7 +1737,7 @@
             "type": "Propinsi",
             "type_en": "Province",
             "code_local": null,
-            "code_hasc": "ID.SL",
+            "code_hasc": "ID.SS",
             "note": null,
             "hasc_maybe": null,
             "region": null,


### PR DESCRIPTION
This PR updates Sumatera Selatan (South Sumatera) `code_hasc` to allow the display of the data on the chart after clicking on the map of GHG emissions section of provinces module.
Test here: 
http://localhost:3000/en/regions/ID.AC/regions-ghg-emissions

![kapture 2019-03-07 at 16 11 43](https://user-images.githubusercontent.com/6906348/53966673-e5508200-40f3-11e9-8b2c-8376487bab75.gif)
 