### PR TITLE
ghg: fix override option

### DIFF
--- a/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-component.jsx
+++ b/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-component.jsx
@@ -11,6 +11,8 @@ import { format } from 'd3-format';
 import startCase from 'lodash/startCase';
 import kebabCase from 'lodash/kebabCase';
 import castArray from 'lodash/castArray';
+import uniq from 'lodash/uniq';
+import flatMap from 'lodash/flatMap';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
 
 import dropdownStyles from 'styles/dropdown.scss';
@@ -36,7 +38,9 @@ class Historical extends PureComponent {
 
     const values = newSelectedOption && newSelectedOption.override
       ? newSelectedOption.value
-      : removedAnyPreviousOverride.map(v => v.value).join(',');
+      : uniq(
+        flatMap(removedAnyPreviousOverride, v => String(v.value).split(','))
+      ).join(',');
 
     onFilterChange({ [field]: values });
   };

--- a/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-filter-selectors.js
+++ b/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-filter-selectors.js
@@ -88,7 +88,8 @@ const getFieldOptions = field =>
       const transformToOption = o => ({
         label: o.label,
         value: String(o.value),
-        code: o.iso_code3 || o.code || o.label
+        code: o.iso_code3 || o.code || o.label,
+        override: o.override
       });
 
       let options = metadata[field];

--- a/app/javascript/app/pages/regions/regions-ghg-emissions/regions-ghg-emissions-component.jsx
+++ b/app/javascript/app/pages/regions/regions-ghg-emissions/regions-ghg-emissions-component.jsx
@@ -4,6 +4,8 @@ import castArray from 'lodash/castArray';
 import toArray from 'lodash/toArray';
 import kebabCase from 'lodash/kebabCase';
 import groupBy from 'lodash/groupBy';
+import uniq from 'lodash/uniq';
+import flatMap from 'lodash/flatMap';
 import { format } from 'd3-format';
 
 import { Chart, Dropdown, Multiselect } from 'cw-components';
@@ -38,7 +40,9 @@ class RegionsGhgEmissions extends PureComponent {
 
     const values = newSelectedOption && newSelectedOption.override
       ? newSelectedOption.value
-      : removedAnyPreviousOverride.map(v => v.value).join(',');
+      : uniq(
+        flatMap(removedAnyPreviousOverride, v => String(v.value).split(','))
+      ).join(',');
 
     onFilterChange({ [field]: values });
   };


### PR DESCRIPTION
Selecting `National` or `Top 10 Emitters` was always resetting the region's selection to only that item. It got broken along the way and this PR resolves that regression.

As the override selection option got lost there was a bug with regions being selected many times in the Dropdown which looks like does not prevent this which cases issues described here https://basecamp.com/1756858/projects/15229620/todos/382454837, like "55 selected" and we don't even have that many.

Don't worry about that dropdown menu flickering in the below gif. Dropdown does not play nicely with my software to record gifs.

![regions-selector](https://user-images.githubusercontent.com/1286444/54226952-2931f580-44ff-11e9-9b39-88e27bbda42f.gif)
