### PR TITLE
Increase left margin for 'Province module' link & change 'No Data' ma…

### DIFF
--- a/app/javascript/app/components/header/header-styles.scss
+++ b/app/javascript/app/components/header/header-styles.scss
@@ -142,6 +142,10 @@ $flag-height: 40px;
 
 .leftTabs {
   display: flex;
+
+  > *:last-child {
+    margin-left: 15px;
+  }
 }
 
 .rightTabs {

--- a/app/javascript/app/pages/national-context/sectoral-activity/selectors/sectoral-activity-constants.js
+++ b/app/javascript/app/pages/national-context/sectoral-activity/selectors/sectoral-activity-constants.js
@@ -16,7 +16,7 @@ export const SECTION_COLORS = {
   ENERGY: '#2EC9DF',
   FORESTRY: '#FCA683',
   INDUSTRIAL_PROCESS_AND_PRODUCT_USE: '#FFC735',
-  'no-data': '#FAFAFA'
+  'no-data': '#868697'
 };
 
 // colors for activities


### PR DESCRIPTION
This PR fixes two tiny issues: adds left margin for `Province module` option and changes `No Data` map color to grey.
Province module margin: [BASECAMP](https://www.pivotaltracker.com/story/show/164011110)
Review legend colors: [BASECAMP](https://www.pivotaltracker.com/story/show/164567904) | [SLACK thread with Fausto](https://vizzuality.slack.com/archives/C6DFY8GVC/p1552476715010000) 


![Screenshot from 2019-03-13 15 22 56](https://user-images.githubusercontent.com/15097138/54291203-24734d00-45a4-11e9-9177-237910f177cb.png)
