### PR TITLE
Add translation to documents dropdown in Climate Goals

### DIFF
--- a/app/javascript/app/layouts/sections/sections-component.jsx
+++ b/app/javascript/app/layouts/sections/sections-component.jsx
@@ -65,7 +65,7 @@ class Section extends PureComponent {
                   <React.Fragment>
                     <Dropdown
                       className={theme.dropdownOptionWithArrow}
-                      placeholder="Read Indonesia's NDC documents"
+                      placeholder={t('pages.climate-goals.overview.dropdown-documents-placeholder')}
                       options={NDC_LINKS_OPTIONS}
                       onValueChange={this.handleDocumentDropdownClick}
                     />

--- a/config/locales/en/app/pages/climate_goals.yml
+++ b/config/locales/en/app/pages/climate_goals.yml
@@ -10,6 +10,7 @@ en:
           title: Overview
           description: ''
           overview-title: Indonesia's climate commitment
+          dropdown-documents-placeholder: Read Indonesia's NDC documents
           button-title: Compare with other countries
           mitigation-contribution: Mitigation contribution
           adaptation-contribution: Adaptation contribution


### PR DESCRIPTION
This PR enables translation for NDC/INDC documents dropdown in Climate Goals page.
[PIVOTAL](https://www.pivotaltracker.com/story/show/164610179) | [BASECAMP](https://basecamp.com/1756858/projects/15229620/todos/382579112)