### PR TITLE
emission drivers/sectoral activities: changing data source for Primary source of emissions indicator

### DIFF
--- a/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-component.jsx
+++ b/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-component.jsx
@@ -189,7 +189,7 @@ SectoralActivity.propTypes = {
   onFilterChange: PropTypes.func.isRequired,
   adaptationParams: PropTypes.object.isRequired,
   adaptationCode: PropTypes.string.isRequired,
-  emissionParams: PropTypes.object.isRequired,
+  emissionParams: PropTypes.object,
   activitySelectable: PropTypes.bool.isRequired,
   activityOptions: PropTypes.array,
   selectedActivity: PropTypes.object,
@@ -203,7 +203,8 @@ SectoralActivity.defaultProps = {
   selectedOptions: {},
   activityOptions: [],
   selectedActivity: {},
-  sources: []
+  sources: [],
+  emissionParams: null
 };
 
 export default SectoralActivity;

--- a/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-component.jsx
+++ b/app/javascript/app/pages/national-context/sectoral-activity/sectoral-activity-component.jsx
@@ -6,8 +6,10 @@ import { Dropdown, PlayTimeline } from 'cw-components';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
 import Map from 'components/map';
 import DotLegend from 'components/dot-legend';
-import EmissionActivitiesProvider from 'providers/emission-activities-provider';
 import AdaptationProvider from 'providers/adaptation-provider';
+import EmissionActivitiesProvider from 'providers/emission-activities-provider';
+import GHGEmissionsProvider from 'providers/ghg-emissions-provider';
+import MetadataProvider from 'providers/metadata-provider';
 import dropdownStyles from 'styles/dropdown.scss';
 import MapTooltip from './map-tooltip';
 
@@ -115,6 +117,7 @@ class SectoralActivity extends Component {
     const {
       map,
       adaptationParams,
+      emissionParams,
       selectedOptions,
       adaptationCode,
       sources,
@@ -146,26 +149,28 @@ class SectoralActivity extends Component {
             />
           </div>
           <EmissionActivitiesProvider />
-          <AdaptationProvider params={adaptationParams} />
+          <MetadataProvider meta="ghgindo" />
+          {emissionParams && <GHGEmissionsProvider params={emissionParams} />}
+          {adaptationParams && <AdaptationProvider params={adaptationParams} />}
         </div>
         <div className={styles.mapSection}>
           <div className={styles.mapContainer}>
             {
               map && (
-                  <React.Fragment>
-                    <Map
-                      zoom={5}
-                      paths={map.paths}
-                      forceUpdate
-                      center={MAP_CENTER}
-                      className={styles.map}
-                      tooltip={MapTooltip}
-                    />
-                    <div className={styles.legend}>
-                      <DotLegend legend={map.legend} />
-                    </div>
-                    {yearsSelectable && this.renderTimeline()}
-                  </React.Fragment>
+              <React.Fragment>
+                <Map
+                  zoom={5}
+                  paths={map.paths}
+                  forceUpdate
+                  center={MAP_CENTER}
+                  className={styles.map}
+                  tooltip={MapTooltip}
+                />
+                <div className={styles.legend}>
+                  <DotLegend legend={map.legend} />
+                </div>
+                {yearsSelectable && this.renderTimeline()}
+              </React.Fragment>
                 )
             }
           </div>
@@ -184,6 +189,7 @@ SectoralActivity.propTypes = {
   onFilterChange: PropTypes.func.isRequired,
   adaptationParams: PropTypes.object.isRequired,
   adaptationCode: PropTypes.string.isRequired,
+  emissionParams: PropTypes.object.isRequired,
   activitySelectable: PropTypes.bool.isRequired,
   activityOptions: PropTypes.array,
   selectedActivity: PropTypes.object,

--- a/app/javascript/app/pages/national-context/sectoral-activity/selectors/sectoral-activity-redux-selectors.js
+++ b/app/javascript/app/pages/national-context/sectoral-activity/selectors/sectoral-activity-redux-selectors.js
@@ -1,6 +1,12 @@
 export const getEmissionActivities = ({ emissionActivities }) =>
   emissionActivities && emissionActivities.data;
 
+export const getMetadataData = ({ metadata }) =>
+  metadata && metadata.ghgindo && metadata.ghgindo.data;
+
+export const getGHGEmissionData = ({ GHGEmissions }) =>
+  GHGEmissions && GHGEmissions.data || null;
+
 export const getAdaptation = ({ adaptation }) => adaptation && adaptation.data;
 
 export const getQuery = ({ location }) => location && location.query || null;

--- a/app/javascript/app/pages/national-context/sectoral-activity/selectors/sectoral-activity-selectors.js
+++ b/app/javascript/app/pages/national-context/sectoral-activity/selectors/sectoral-activity-selectors.js
@@ -351,7 +351,7 @@ const getPathsWithStylesForAdaptationSelector = createSelector(
 const getIsActivitySelectable = createSelector(
   [ getSelectedIndicator ],
   selectedIndicator => {
-    if (!selectedIndicator) return null;
+    if (!selectedIndicator) return false;
 
     return isActivitySelectable(selectedIndicator);
   }


### PR DESCRIPTION
Changing the data source for `Primary source of emissions` indicator to main GHG emissions data.

[Basecamp conversation](https://basecamp.com/1756858/projects/15229620/todos/382579416)
[Pivotal](https://www.pivotaltracker.com/story/show/164567939)