### PR TITLE
Fix/changing ghg emissions hardcoded source take target units from api

### DIFF
--- a/app/javascript/app/constants/constants.js
+++ b/app/javascript/app/constants/constants.js
@@ -13,7 +13,7 @@ export const METRIC = {
 };
 export const API = { cw: 'CW', indo: 'INDO' };
 export const EMISSION_TARGET = { bau: 'BAU', target: 'TARGET' };
-export const SOURCE = { SIGN_SMART: 'SIGN SMART', CAIT: 'CAIT' };
+export const SOURCE = { SIGN_SMART: 'SIGNSa', CAIT: 'CAIT' };
 export const SECTOR_TOTAL = 'TOTAL';
 export const NDC_LINKS_OPTIONS = [
   { value: 'ndc', label: 'NDC (EN)' },

--- a/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-fetch-selectors.js
+++ b/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-fetch-selectors.js
@@ -25,7 +25,7 @@ export const getEmissionParams = createSelector(
       api: selectedSource.api,
       location: COUNTRY_ISO,
       ...getParam('gas', gas),
-      source: findOption(metadata.dataSource, selectedSource.label).value
+      source: findOption(metadata.dataSource, selectedSource.value).value
     };
   }
 );

--- a/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-filter-selectors.js
+++ b/app/javascript/app/pages/national-context/historical-emissions/historical-emissions-selectors/historical-emissions-filter-selectors.js
@@ -29,12 +29,7 @@ const CHART_TYPE_OPTIONS = [
 ];
 
 const SOURCE_OPTIONS = [
-  {
-    label: 'SIGN SMART',
-    name: 'SIGN SMART',
-    value: 'SIGN_SMART',
-    api: API.indo
-  },
+  { label: 'SIGN SMART', name: 'SIGN SMART', value: 'SIGNSa', api: API.indo },
   { label: 'CAIT', name: 'CAIT', value: 'CAIT', api: API.cw }
 ];
 

--- a/app/javascript/app/pages/regions/regions-ghg-emissions/emission-target-chart/emission-target-chart-component.jsx
+++ b/app/javascript/app/pages/regions/regions-ghg-emissions/emission-target-chart/emission-target-chart-component.jsx
@@ -8,6 +8,14 @@ import { PieChart } from 'cw-components';
 import styles from './emission-target-chart-styles.scss';
 
 const CHART_THEME = [ '#FF6C2F', '#03209F', '#0845CB' ];
+const EMISSION_TARGET_UNIT = 'tCO2e';
+
+const getScale = unit => {
+  if (unit.startsWith('kt')) return 1000;
+  if (unit.startsWith('Mt')) return 1000000;
+  return 1;
+};
+const convertUnit = (value, unit) => value * getScale(unit);
 
 class EmissionTargetChart extends PureComponent {
   render() {
@@ -23,9 +31,12 @@ class EmissionTargetChart extends PureComponent {
     }));
 
     const emissionTarget = emissionTargets[0];
-    const { year, label, unit } = emissionTarget;
+    const { year, label } = emissionTarget;
 
-    const data = targets.map(et => ({ name: et.sector, value: et.value }));
+    const data = targets.map(et => ({
+      name: et.sector,
+      value: convertUnit(et.value, et.unit)
+    }));
     const theme = targets.reduce(
       (acc, et, index) => ({
         ...acc,
@@ -45,7 +56,7 @@ class EmissionTargetChart extends PureComponent {
     const config = {
       tooltip,
       animation: false,
-      axes: { yLeft: { unit, label: year } },
+      axes: { yLeft: { unit: EMISSION_TARGET_UNIT, label: year } },
       theme
     };
 

--- a/app/javascript/app/pages/regions/regions-ghg-emissions/emission-target-chart/emission-target-chart-component.jsx
+++ b/app/javascript/app/pages/regions/regions-ghg-emissions/emission-target-chart/emission-target-chart-component.jsx
@@ -7,7 +7,6 @@ import { PieChart } from 'cw-components';
 
 import styles from './emission-target-chart-styles.scss';
 
-const EMISSION_TARGET_UNIT = 'MtCO2e';
 const CHART_THEME = [ '#FF6C2F', '#03209F', '#0845CB' ];
 
 class EmissionTargetChart extends PureComponent {
@@ -24,7 +23,7 @@ class EmissionTargetChart extends PureComponent {
     }));
 
     const emissionTarget = emissionTargets[0];
-    const { year, label } = emissionTarget;
+    const { year, label, unit } = emissionTarget;
 
     const data = targets.map(et => ({ name: et.sector, value: et.value }));
     const theme = targets.reduce(
@@ -46,7 +45,7 @@ class EmissionTargetChart extends PureComponent {
     const config = {
       tooltip,
       animation: false,
-      axes: { yLeft: { unit: EMISSION_TARGET_UNIT, label: year } },
+      axes: { yLeft: { unit, label: year } },
       theme
     };
 

--- a/app/services/import_emission_targets.rb
+++ b/app/services/import_emission_targets.rb
@@ -29,6 +29,8 @@ class ImportEmissionTargets
   # rubocop:disable MethodLength, AbcSize
   def import_data
     import_each_with_logging(csv, DATA_FILEPATH) do |row|
+      next unless row[:value].present?
+
       location = Location.find_by(iso_code3: row[:geoid])
       label = EmissionTarget::Label.find_or_create_by!(name: row[:label])
       sector = EmissionTarget::Sector.find_or_create_by!(name: row[:sector])


### PR DESCRIPTION
- Uploading new GHG emission data. 
- Source name was changed from `SIGN SMART` to `SIGNSa` probably to be in line with what is in the source metadata.
- Units for emission targets have been corrected, also I changed the displayed unit in regional emission targets pie charts to be `tCO2e`.

```
bundle exec rake historical_emissions:import
bundle exec rake emission_targets:import
```
